### PR TITLE
[llvm-context,solidity] Generate debug-info location information.     

### DIFF
--- a/crates/llvm-context/src/lib.rs
+++ b/crates/llvm-context/src/lib.rs
@@ -16,6 +16,7 @@ pub use self::polkavm::context::argument::Argument as PolkaVMArgument;
 pub use self::polkavm::context::attribute::Attribute as PolkaVMAttribute;
 pub use self::polkavm::context::build::Build as PolkaVMBuild;
 pub use self::polkavm::context::code_type::CodeType as PolkaVMCodeType;
+pub use self::polkavm::context::debug_info::DebugInfo;
 pub use self::polkavm::context::evmla_data::EVMLAData as PolkaVMContextEVMLAData;
 pub use self::polkavm::context::function::block::evmla_data::key::Key as PolkaVMFunctionBlockKey;
 pub use self::polkavm::context::function::block::evmla_data::EVMLAData as PolkaVMFunctionBlockEVMLAData;

--- a/crates/llvm-context/src/optimizer/settings/mod.rs
+++ b/crates/llvm-context/src/optimizer/settings/mod.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 
 use self::size_level::SizeLevel;
 
-/// The LLVM optimizer settings.
+/// The LLVM optimizer and code-gen settings.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq)]
 pub struct Settings {
     /// The middle-end optimization level.
@@ -28,6 +28,9 @@ pub struct Settings {
     pub is_verify_each_enabled: bool,
     /// Whether the LLVM `debug logging` option is enabled.
     pub is_debug_logging_enabled: bool,
+
+    /// Whether to generate source-level debug information.
+    pub emit_debug_info: bool,
 }
 
 impl Settings {
@@ -47,6 +50,8 @@ impl Settings {
 
             is_verify_each_enabled: false,
             is_debug_logging_enabled: false,
+
+            emit_debug_info: false,
         }
     }
 
@@ -58,6 +63,8 @@ impl Settings {
 
         is_verify_each_enabled: bool,
         is_debug_logging_enabled: bool,
+
+        emit_debug_info: bool,
     ) -> Self {
         Self {
             level_middle_end,
@@ -69,6 +76,8 @@ impl Settings {
 
             is_verify_each_enabled,
             is_debug_logging_enabled,
+
+            emit_debug_info,
         }
     }
 
@@ -219,6 +228,11 @@ impl Settings {
     /// Whether the system request memoization is disabled.
     pub fn is_system_request_memoization_disabled(&self) -> bool {
         self.is_system_request_memoization_disabled
+    }
+
+    /// Whether source-level debug information should be emitted.
+    pub fn emit_debug_info(&self) -> bool {
+        return self.emit_debug_info;
     }
 }
 

--- a/crates/llvm-context/src/polkavm/context/debug_info.rs
+++ b/crates/llvm-context/src/polkavm/context/debug_info.rs
@@ -1,7 +1,43 @@
 //! The LLVM debug information.
 
+use std::cell::RefCell;
+
 use inkwell::debug_info::AsDIScope;
-use num::Zero;
+use inkwell::debug_info::DIScope;
+
+/// Debug info scope stack
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopeStack<'ctx> {
+    stack: Vec<DIScope<'ctx>>,
+}
+
+// Abstract the type of the DIScope stack.
+impl<'ctx> ScopeStack<'ctx> {
+    pub fn from(item: DIScope<'ctx>) -> Self {
+        Self { stack: vec![item] }
+    }
+
+    /// Return the top of the scope stack, or None if the stack is empty.
+    pub fn top(&self) -> Option<DIScope<'ctx>> {
+        self.stack.last().map(|rc| rc.clone())
+    }
+
+    /// Push a scope onto the stack.
+    pub fn push(&mut self, scope: DIScope<'ctx>) -> () {
+        self.stack.push(scope)
+    }
+
+    /// Pop the scope at the top of the stack and return it.
+    /// Return None if the stack is empty.
+    pub fn pop(&mut self) -> Option<DIScope<'ctx>> {
+        self.stack.pop()
+    }
+
+    /// Return the number of scopes on the stack.
+    pub fn len(&self) -> usize {
+        self.stack.len()
+    }
+}
 
 /// The LLVM debug information.
 pub struct DebugInfo<'ctx> {
@@ -9,6 +45,10 @@ pub struct DebugInfo<'ctx> {
     compile_unit: inkwell::debug_info::DICompileUnit<'ctx>,
     /// The debug info builder.
     builder: inkwell::debug_info::DebugInfoBuilder<'ctx>,
+    /// Enclosing debug info scopes.
+    scope_stack: RefCell<ScopeStack<'ctx>>,
+    // Names of enclosing objects, functions and other namespaces.
+    namespace_stack: RefCell<Vec<String>>,
 }
 
 impl<'ctx> DebugInfo<'ctx> {
@@ -35,63 +75,150 @@ impl<'ctx> DebugInfo<'ctx> {
         Self {
             compile_unit,
             builder,
+            scope_stack: RefCell::new(ScopeStack::from(compile_unit.as_debug_info_scope())),
+            namespace_stack: RefCell::new(vec![]),
         }
     }
 
-    /// Creates a function info.
+    /// Prepare an LLVM-IR module for debug-info generation
+    pub fn initialize_module(
+        &self,
+        llvm: &'ctx inkwell::context::Context,
+        module: &inkwell::module::Module<'ctx>,
+    ) {
+        let debug_metadata_value = llvm
+            .i32_type()
+            .const_int(inkwell::debug_info::debug_metadata_version() as u64, false);
+        module.add_basic_value_flag(
+            "Debug Info Version",
+            inkwell::module::FlagBehavior::Warning,
+            debug_metadata_value,
+        );
+    }
+
+    /// Create debug-info for a function.
     pub fn create_function(
         &self,
+        scope: inkwell::debug_info::DIScope<'ctx>,
         name: &str,
+        linkage_name: Option<&str>,
+        return_type: Option<inkwell::debug_info::DIType<'ctx>>,
+        parameter_types: &[inkwell::debug_info::DIType<'ctx>],
+        file: inkwell::debug_info::DIFile<'ctx>,
+        line_num: u32,
+        is_definition: bool,
+        is_local: bool,
+        is_optimized: bool,
+        flags: Option<inkwell::debug_info::DIFlags>,
     ) -> anyhow::Result<inkwell::debug_info::DISubprogram<'ctx>> {
-        let subroutine_type = self.builder.create_subroutine_type(
-            self.compile_unit.get_file(),
-            Some(self.create_type(revive_common::BIT_LENGTH_FIELD)?),
-            &[],
-            inkwell::debug_info::DIFlags::zero(),
-        );
+        let di_flags = flags.unwrap_or(inkwell::debug_info::DIFlagsConstants::ZERO);
+        let ret_type = return_type.unwrap_or(self.create_word_type(flags)?.as_type());
+        let subroutine_type =
+            self.builder
+                .create_subroutine_type(file, Some(ret_type), parameter_types, di_flags);
 
         let function = self.builder.create_function(
-            self.compile_unit.get_file().as_debug_info_scope(),
+            scope,
             name,
-            None,
-            self.compile_unit.get_file(),
-            42,
+            linkage_name,
+            file,
+            line_num,
             subroutine_type,
-            true,
-            false,
+            is_local,
+            is_definition,
             1,
-            inkwell::debug_info::DIFlags::zero(),
-            false,
-        );
-
-        self.builder.create_lexical_block(
-            function.as_debug_info_scope(),
-            self.compile_unit.get_file(),
-            1,
-            1,
+            di_flags,
+            is_optimized,
         );
 
         Ok(function)
     }
 
-    /// Creates a primitive type info.
-    pub fn create_type(
+    /// Creates primitive integer type debug-info.
+    pub fn create_primitive_type(
         &self,
         bit_length: usize,
-    ) -> anyhow::Result<inkwell::debug_info::DIType<'ctx>> {
+        flags: Option<inkwell::debug_info::DIFlags>,
+    ) -> anyhow::Result<inkwell::debug_info::DIBasicType<'ctx>> {
+        let di_flags = flags.unwrap_or(inkwell::debug_info::DIFlagsConstants::ZERO);
+        let di_encoding: u32 = 0;
+        let type_name = String::from("U") + bit_length.to_string().as_str();
         self.builder
-            .create_basic_type(
-                "U256",
-                bit_length as u64,
-                0,
-                inkwell::debug_info::DIFlags::zero(),
-            )
-            .map(|basic_type| basic_type.as_type())
+            .create_basic_type(type_name.as_str(), bit_length as u64, di_encoding, di_flags)
             .map_err(|error| anyhow::anyhow!("Debug info error: {}", error))
     }
 
-    /// Finalizes the builder.
-    pub fn finalize(&self) {
-        self.builder.finalize();
+    /// Returns the debug-info model of word-sized integer types.
+    pub fn create_word_type(
+        &self,
+        flags: Option<inkwell::debug_info::DIFlags>,
+    ) -> anyhow::Result<inkwell::debug_info::DIBasicType<'ctx>> {
+        self.create_primitive_type(revive_common::BIT_LENGTH_WORD, flags)
+    }
+
+    /// Return the DIBuilder.
+    pub fn builder(&self) -> &inkwell::debug_info::DebugInfoBuilder<'ctx> {
+        &self.builder
+    }
+
+    /// Return the compilation unit. {
+    pub fn compilation_unit(&self) -> &inkwell::debug_info::DICompileUnit<'ctx> {
+        &self.compile_unit
+    }
+
+    /// Push a debug-info scope onto the stack.
+    pub fn push_scope(&self, scope: DIScope<'ctx>) -> () {
+        self.scope_stack.borrow_mut().push(scope)
+    }
+
+    /// Pop the top of the debug-info scope stack and return it.
+    pub fn pop_scope(&self) -> Option<DIScope<'ctx>> {
+        self.scope_stack.borrow_mut().pop()
+    }
+
+    /// Return the top of the debug-info scope stack.
+    pub fn top_scope(&self) -> Option<DIScope<'ctx>> {
+        self.scope_stack.borrow().top()
+    }
+
+    /// Return the number of debug-info scopes on the scope stack.
+    pub fn num_scopes(&self) -> usize {
+        self.scope_stack.borrow().len()
+    }
+
+    /// Push a name onto the namespace stack.
+    pub fn push_namespace(&self, name: String) -> () {
+        self.namespace_stack.borrow_mut().push(name);
+    }
+
+    /// Pop the top name off the namespace stack and return it.
+    pub fn pop_namespace(&self) -> Option<String> {
+        self.namespace_stack.borrow_mut().pop()
+    }
+
+    /// Return the top of the namespace stack.
+    pub fn top_namespace(&self) -> Option<String> {
+        self.namespace_stack.borrow().last().map(|rc| rc.clone())
+    }
+
+    // Get a string representation of the namespace stack. Optionally append the given name.
+    pub fn namespace_as_identifier(&self, name: Option<&str>) -> String {
+        let separator = "::";
+        let mut ret = String::new();
+        let mut sep = false;
+        for s in self.namespace_stack.borrow().iter() {
+            if sep {
+                ret.push_str(separator);
+            };
+            sep = true;
+            ret.push_str(s)
+        }
+        if let Some(n) = name {
+            if sep {
+                ret.push_str(separator);
+            };
+            ret.push_str(n);
+        }
+        ret
     }
 }

--- a/crates/llvm-context/src/polkavm/context/function/declaration.rs
+++ b/crates/llvm-context/src/polkavm/context/function/declaration.rs
@@ -17,4 +17,8 @@ impl<'ctx> Declaration<'ctx> {
     ) -> Self {
         Self { r#type, value }
     }
+
+    pub fn function_value(&self) -> inkwell::values::FunctionValue<'ctx> {
+        self.value
+    }
 }

--- a/crates/llvm-context/src/polkavm/context/function/runtime/deploy_code.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/deploy_code.rs
@@ -8,6 +8,8 @@ use crate::polkavm::context::Context;
 use crate::polkavm::Dependency;
 use crate::polkavm::WriteLLVM;
 
+use inkwell::debug_info::AsDIScope;
+
 /// The deploy code function.
 /// Is a special function that is only used by the front-end generated code.
 #[derive(Debug)]
@@ -60,6 +62,46 @@ where
         context.set_basic_block(context.current_function().borrow().entry_block());
         context.set_code_type(CodeType::Deploy);
 
+        if let Some(dinfo) = context.debug_info() {
+            context.builder().unset_current_debug_location();
+            let di_builder = dinfo.builder();
+            let line_num: u32 = 0;
+            let column: u32 = 0;
+            let func_name: &str = runtime::FUNCTION_DEPLOY_CODE;
+            let linkage_name = dinfo.namespace_as_identifier(Some(func_name).clone());
+            let di_file = dinfo.compilation_unit().get_file();
+            let di_scope = di_file.as_debug_info_scope();
+            let di_func_scope = dinfo.create_function(
+                di_scope,
+                func_name,
+                Some(linkage_name.as_str()),
+                None,
+                &[],
+                di_file,
+                line_num,
+                true,
+                false,
+                false,
+                Some(inkwell::debug_info::DIFlagsConstants::PUBLIC),
+            )?;
+            let func_value = context
+                .current_function()
+                .borrow()
+                .declaration()
+                .function_value();
+            let _ = func_value.set_subprogram(di_func_scope);
+
+            let lexical_scope = di_builder
+                .create_lexical_block(
+                    di_func_scope.as_debug_info_scope(),
+                    dinfo.compilation_unit().get_file(),
+                    line_num,
+                    column,
+                )
+                .as_debug_info_scope();
+            let _ = dinfo.push_scope(lexical_scope);
+        }
+
         self.inner.into_llvm(context)?;
         match context
             .basic_block()
@@ -73,7 +115,28 @@ where
         }
 
         context.set_basic_block(context.current_function().borrow().return_block());
+        if let Some(dinfo) = context.debug_info() {
+            context.builder().unset_current_debug_location();
+            let di_builder = dinfo.builder();
+            let line_num: u32 = 0x0beef;
+            let di_parent_scope = dinfo
+                .top_scope()
+                .expect("expected an existing debug-info scope")
+                .clone();
+            let di_loc = di_builder.create_debug_location(
+                context.llvm(),
+                line_num,
+                0,
+                di_parent_scope,
+                None,
+            );
+            context.builder().set_current_debug_location(di_loc)
+        }
         context.build_return(None);
+
+        if let Some(dinfo) = context.debug_info() {
+            let _ = dinfo.pop_scope();
+        }
 
         Ok(())
     }

--- a/crates/llvm-context/src/polkavm/context/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/mod.rs
@@ -5,7 +5,7 @@ pub mod argument;
 pub mod attribute;
 pub mod build;
 pub mod code_type;
-// pub mod debug_info;
+pub mod debug_info;
 pub mod evmla_data;
 pub mod function;
 pub mod global;
@@ -36,7 +36,7 @@ use self::address_space::AddressSpace;
 use self::attribute::Attribute;
 use self::build::Build;
 use self::code_type::CodeType;
-// use self::debug_info::DebugInfo;
+use self::debug_info::DebugInfo;
 use self::evmla_data::EVMLAData;
 use self::function::declaration::Declaration as FunctionDeclaration;
 use self::function::intrinsics::Intrinsics;
@@ -86,7 +86,7 @@ where
     /// Whether to append the metadata hash at the end of bytecode.
     include_metadata_hash: bool,
     /// The debug info of the current module.
-    // debug_info: DebugInfo<'ctx>,
+    debug_info: Option<DebugInfo<'ctx>>,
     /// The debug configuration telling whether to dump the needed IRs.
     debug_config: Option<DebugConfig>,
 
@@ -196,6 +196,7 @@ where
         optimizer: Optimizer,
         dependency_manager: Option<D>,
         include_metadata_hash: bool,
+        debug_info: Option<DebugInfo<'ctx>>,
         debug_config: Option<DebugConfig>,
     ) -> Self {
         Self::link_stdlib_module(llvm, &module);
@@ -221,7 +222,7 @@ where
 
             dependency_manager,
             include_metadata_hash,
-            // debug_info,
+            debug_info,
             debug_config,
 
             solidity_data: None,
@@ -572,6 +573,11 @@ where
         self.dependency_manager
             .take()
             .expect("The dependency manager is unset")
+    }
+
+    /// Returns the debug info.
+    pub fn debug_info(&self) -> Option<&DebugInfo<'ctx>> {
+        self.debug_info.as_ref()
     }
 
     /// Returns the debug config reference.

--- a/crates/llvm-context/src/polkavm/context/tests.rs
+++ b/crates/llvm-context/src/polkavm/context/tests.rs
@@ -15,7 +15,7 @@ pub fn create_context(
     let module = llvm.create_module("test");
     let optimizer = Optimizer::new(optimizer_settings);
 
-    Context::<DummyDependency>::new(llvm, module, optimizer, None, true, None)
+    Context::<DummyDependency>::new(llvm, module, optimizer, None, true, None, None)
 }
 
 #[test]

--- a/crates/llvm-context/src/polkavm/context/tests.rs
+++ b/crates/llvm-context/src/polkavm/context/tests.rs
@@ -15,7 +15,7 @@ pub fn create_context(
     let module = llvm.create_module("test");
     let optimizer = Optimizer::new(optimizer_settings);
 
-    Context::<DummyDependency>::new(llvm, module, optimizer, None, true, None, None)
+    Context::<DummyDependency>::new(llvm, module, optimizer, None, true, false, None, None)
 }
 
 #[test]

--- a/crates/llvm-context/src/polkavm/mod.rs
+++ b/crates/llvm-context/src/polkavm/mod.rs
@@ -99,6 +99,7 @@ pub trait Dependency {
         optimizer_settings: OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        emit_llvm_ir: bool,
         debug_config: Option<DebugConfig>,
     ) -> anyhow::Result<String>;
 
@@ -120,6 +121,7 @@ impl Dependency for DummyDependency {
         _optimizer_settings: OptimizerSettings,
         _is_system_mode: bool,
         _include_metadata_hash: bool,
+        _emit_llvm_ir: bool,
         _debug_config: Option<DebugConfig>,
     ) -> anyhow::Result<String> {
         Ok(String::new())

--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -53,6 +53,7 @@ pub fn yul(
     optimizer_settings: revive_llvm_context::OptimizerSettings,
     is_system_mode: bool,
     include_metadata_hash: bool,
+    emit_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
 ) -> anyhow::Result<Build> {
     let path = match input_files.len() {
@@ -83,6 +84,7 @@ pub fn yul(
         optimizer_settings,
         is_system_mode,
         include_metadata_hash,
+        emit_llvm_ir,
         debug_config,
     )?;
 
@@ -112,6 +114,7 @@ pub fn llvm_ir(
         optimizer_settings,
         is_system_mode,
         include_metadata_hash,
+        false,
         debug_config,
     )?;
 
@@ -135,6 +138,7 @@ pub fn standard_output(
     allow_paths: Option<String>,
     remappings: Option<BTreeSet<String>>,
     suppressed_warnings: Option<Vec<Warning>>,
+    emit_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
 ) -> anyhow::Result<Build> {
     let solc_version = solc.version()?;
@@ -202,6 +206,7 @@ pub fn standard_output(
         optimizer_settings,
         is_system_mode,
         include_metadata_hash,
+        emit_llvm_ir,
         debug_config,
     )?;
 
@@ -218,6 +223,7 @@ pub fn standard_json(
     base_path: Option<String>,
     include_paths: Vec<String>,
     allow_paths: Option<String>,
+    emit_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
 ) -> anyhow::Result<()> {
     let solc_version = solc.version()?;
@@ -279,6 +285,7 @@ pub fn standard_json(
             optimizer_settings,
             is_system_mode,
             include_metadata_hash,
+            emit_llvm_ir,
             debug_config,
         )?;
         build.write_to_standard_json(&mut solc_output, &solc_version, &resolc_version)?;
@@ -305,6 +312,7 @@ pub fn combined_json(
     allow_paths: Option<String>,
     remappings: Option<BTreeSet<String>>,
     suppressed_warnings: Option<Vec<Warning>>,
+    emit_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
     output_directory: Option<PathBuf>,
     overwrite: bool,
@@ -326,6 +334,7 @@ pub fn combined_json(
         allow_paths,
         remappings,
         suppressed_warnings,
+        emit_llvm_ir,
         debug_config,
     )?;
 

--- a/crates/solidity/src/process/input.rs
+++ b/crates/solidity/src/process/input.rs
@@ -20,6 +20,8 @@ pub struct Input {
     pub include_metadata_hash: bool,
     /// The optimizer settings.
     pub optimizer_settings: revive_llvm_context::OptimizerSettings,
+    /// Whether to output LLVM-IR.
+    pub emit_llvm_ir: bool,
     /// The debug output config.
     pub debug_config: Option<revive_llvm_context::DebugConfig>,
 }
@@ -32,6 +34,7 @@ impl Input {
         is_system_mode: bool,
         include_metadata_hash: bool,
         optimizer_settings: revive_llvm_context::OptimizerSettings,
+        emit_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> Self {
         Self {
@@ -40,6 +43,7 @@ impl Input {
             is_system_mode,
             include_metadata_hash,
             optimizer_settings,
+            emit_llvm_ir,
             debug_config,
         }
     }

--- a/crates/solidity/src/process/mod.rs
+++ b/crates/solidity/src/process/mod.rs
@@ -45,6 +45,7 @@ pub fn run(input_file: Option<&mut std::fs::File>) -> anyhow::Result<()> {
         input.optimizer_settings,
         input.is_system_mode,
         input.include_metadata_hash,
+        input.emit_llvm_ir,
         input.debug_config,
     );
 

--- a/crates/solidity/src/project/contract/mod.rs
+++ b/crates/solidity/src/project/contract/mod.rs
@@ -14,6 +14,7 @@ use revive_llvm_context::PolkaVMWriteLLVM;
 use crate::build::contract::Contract as ContractBuild;
 use crate::project::Project;
 use crate::solc::version::Version as SolcVersion;
+use revive_llvm_context::DebugInfo;
 
 use self::ir::IR;
 use self::metadata::Metadata;
@@ -83,6 +84,7 @@ impl Contract {
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         let llvm = inkwell::context::Context::create();
+        let emit_debug_info = optimizer_settings.emit_debug_info();
         let optimizer = revive_llvm_context::Optimizer::new(optimizer_settings);
 
         let version = project.version.clone();
@@ -106,6 +108,7 @@ impl Contract {
 
         let module = match self.ir {
             IR::LLVMIR(ref llvm_ir) => {
+                // Create the output module
                 let memory_buffer =
                     inkwell::memory_buffer::MemoryBuffer::create_from_memory_range_copy(
                         llvm_ir.source.as_bytes(),
@@ -116,12 +119,22 @@ impl Contract {
             }
             _ => llvm.create_module(self.path.as_str()),
         };
+
+        let debug_info = if emit_debug_info {
+            let debug_info = DebugInfo::new(&module);
+            debug_info.initialize_module(&llvm, &module);
+            Some(debug_info)
+        } else {
+            None
+        };
+
         let mut context = revive_llvm_context::PolkaVMContext::new(
             &llvm,
             module,
             optimizer,
             Some(project),
             include_metadata_hash,
+            debug_info,
             debug_config,
         );
         context.set_solidity_data(revive_llvm_context::PolkaVMContextSolidityData::default());

--- a/crates/solidity/src/project/contract/mod.rs
+++ b/crates/solidity/src/project/contract/mod.rs
@@ -81,6 +81,7 @@ impl Contract {
         optimizer_settings: revive_llvm_context::OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        emit_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         let llvm = inkwell::context::Context::create();
@@ -134,6 +135,7 @@ impl Contract {
             optimizer,
             Some(project),
             include_metadata_hash,
+            emit_llvm_ir,
             debug_info,
             debug_config,
         );

--- a/crates/solidity/src/project/mod.rs
+++ b/crates/solidity/src/project/mod.rs
@@ -64,6 +64,7 @@ impl Project {
         optimizer_settings: revive_llvm_context::OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        emit_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Build> {
         let project = self.clone();
@@ -77,6 +78,7 @@ impl Project {
                     is_system_mode,
                     include_metadata_hash,
                     optimizer_settings.clone(),
+                    emit_llvm_ir,
                     debug_config.clone(),
                 ));
 
@@ -241,6 +243,7 @@ impl revive_llvm_context::PolkaVMDependency for Project {
         optimizer_settings: revive_llvm_context::OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        emit_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<String> {
         let contract_path = project.resolve_path(identifier)?;
@@ -261,6 +264,7 @@ impl revive_llvm_context::PolkaVMDependency for Project {
                 optimizer_settings,
                 is_system_mode,
                 include_metadata_hash,
+                emit_llvm_ir,
                 debug_config,
             )
             .map_err(|error| {

--- a/crates/solidity/src/resolc/arguments.rs
+++ b/crates/solidity/src/resolc/arguments.rs
@@ -149,6 +149,11 @@ pub struct Arguments {
     #[structopt(long = "suppress-warnings")]
     pub suppress_warnings: Option<Vec<String>>,
 
+    /// Generate source based debug information in the output code file. This only has an effect
+    /// with the LLVM-IR code generator and is ignored otherwise.
+    #[structopt(short = 'g')]
+    pub emit_source_debug_info: bool,
+
     /// Dump all IRs to files in the specified directory.
     /// Only for testing and debugging.
     #[structopt(long = "debug-output-dir")]

--- a/crates/solidity/src/resolc/arguments.rs
+++ b/crates/solidity/src/resolc/arguments.rs
@@ -179,6 +179,12 @@ pub struct Arguments {
     #[cfg(debug_assertions)]
     #[structopt(long = "recursive-process-input")]
     pub recursive_process_input: Option<String>,
+
+    /// Output LLVM-IR of the contracts.
+    /// This is only intended for use when developing the compiler.
+    #[cfg(debug_assertions)]
+    #[structopt(long = "emit-llvm-ir")]
+    pub output_llvm_ir: bool,
 }
 
 impl Default for Arguments {
@@ -216,6 +222,13 @@ impl Arguments {
         #[cfg(not(debug_assertions))]
         if self.recursive_process && std::env::args().count() > 2 {
             anyhow::bail!("No other options are allowed in recursive mode.");
+        }
+
+        #[cfg(debug_assertions)]
+        if self.output_llvm_ir {
+            if self.output_assembly || self.output_binary {
+                anyhow::bail!("Can't output LLVM-IR as well as PolkaVM assembly or bytecode.");
+            }
         }
 
         let modes_count = [

--- a/crates/solidity/src/resolc/main.rs
+++ b/crates/solidity/src/resolc/main.rs
@@ -106,6 +106,7 @@ fn main_inner() -> anyhow::Result<()> {
     }
     optimizer_settings.is_verify_each_enabled = arguments.llvm_verify_each;
     optimizer_settings.is_debug_logging_enabled = arguments.llvm_debug_logging;
+    optimizer_settings.emit_debug_info = arguments.emit_source_debug_info;
 
     let include_metadata_hash = match arguments.metadata_hash {
         Some(metadata_hash) => {

--- a/crates/solidity/src/test_utils.rs
+++ b/crates/solidity/src/test_utils.rs
@@ -106,7 +106,7 @@ pub fn build_solidity_with_options(
 
     let project = output.try_to_project(sources, libraries, pipeline, &solc_version, None)?;
 
-    let build: crate::Build = project.compile(optimizer_settings, false, false, None)?;
+    let build: crate::Build = project.compile(optimizer_settings, false, false, false, None)?;
     build.write_to_standard_json(
         &mut output,
         &solc_version,
@@ -229,7 +229,7 @@ pub fn build_yul(source_code: &str) -> anyhow::Result<()> {
 
     let project =
         Project::try_from_yul_string(PathBuf::from("test.yul").as_path(), source_code, None)?;
-    let _build = project.compile(optimizer_settings, false, false, None)?;
+    let _build = project.compile(optimizer_settings, false, false, false, None)?;
 
     Ok(())
 }

--- a/crates/solidity/src/yul/parser/statement/variable_declaration.rs
+++ b/crates/solidity/src/yul/parser/statement/variable_declaration.rs
@@ -91,6 +91,26 @@ impl VariableDeclaration {
     }
 }
 
+fn set_debug_location<'ctx, D>(
+    context: &revive_llvm_context::PolkaVMContext<'ctx, D>,
+    line_num: u32,
+) -> anyhow::Result<()>
+where
+    D: revive_llvm_context::PolkaVMDependency + Clone,
+{
+    if let Some(dinfo) = context.debug_info() {
+        let di_builder = dinfo.builder();
+        let di_parent_scope = dinfo
+            .top_scope()
+            .expect("expected a debug-info scope")
+            .clone();
+        let di_loc =
+            di_builder.create_debug_location(context.llvm(), line_num, 0, di_parent_scope, None);
+        let _ = context.builder().set_current_debug_location(di_loc);
+    }
+    Ok(())
+}
+
 impl<D> revive_llvm_context::PolkaVMWriteLLVM<D> for VariableDeclaration
 where
     D: revive_llvm_context::PolkaVMDependency + Clone,
@@ -101,7 +121,13 @@ where
     ) -> anyhow::Result<()> {
         if self.bindings.len() == 1 {
             let identifier = self.bindings.remove(0);
-            let r#type = identifier.r#type.unwrap_or_default().into_llvm(context);
+            if context.debug_info().is_some() {
+                let line_num: u32 =
+                    std::cmp::min(identifier.location.line, u32::MAX as usize) as u32;
+                let _ = set_debug_location(context, line_num);
+            };
+            let identifier_type = identifier.r#type.clone().unwrap_or_default();
+            let r#type = identifier_type.into_llvm(context);
             let pointer = context.build_alloca(r#type, identifier.inner.as_str());
             context
                 .current_function()
@@ -116,7 +142,7 @@ where
                                 .current_function()
                                 .borrow_mut()
                                 .yul_mut()
-                                .insert_constant(identifier.inner, constant);
+                                .insert_constant(identifier.inner.clone(), constant);
                         }
 
                         value.to_llvm()
@@ -131,6 +157,10 @@ where
         }
 
         for (index, binding) in self.bindings.iter().enumerate() {
+            if context.debug_info().is_some() {
+                let line_num: u32 = std::cmp::min(binding.location.line, u32::MAX as usize) as u32;
+                let _ = set_debug_location(context, line_num);
+            };
             let yul_type = binding
                 .r#type
                 .to_owned()


### PR DESCRIPTION
Generate source level debug information for the functions defined when generating LLVM-IR. This includes the deploy_code and runtime functions generated by the compiler.

Also generate debug-location information for other constructs that may appear.

