### PR TITLE
[workflows] Add workflow for building revive in a debian container.

### DIFF
--- a/.github/workflows/build-revive-debian.yml
+++ b/.github/workflows/build-revive-debian.yml
@@ -1,0 +1,38 @@
+name: Build revive-debian
+on:
+  workflow_dispatch:
+
+env:
+  REVIVE_DEBIAN_PACKAGE: revive-debian-x86
+  DEBIAN_CONTAINER: revive-builder-debian-x86
+  DEBIAN_CONTAINER_BUILDER: build-debian-builder.sh
+  DEBIAN_CONTAINER_RUNNER: run-debian-builder.sh
+  REVIVE_DEBIAN_INSTALL: ${{ github.workspace }}/target/release
+  REVIVE_DEBIAN_BINARY: resolc
+  RUST_VERSION: "1.80"
+
+jobs:
+  build-revive-debian-x86:
+    name: debian-container-x86
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: build-container
+        run: |
+          (cd utils && ./${{ env.DEBIAN_CONTAINER_BUILDER}} --build-arg RUST_VERSION=${{ env.RUST_VERSION}} . )
+
+      - name: build-revive-debian
+        run: |
+          rustup show
+          cargo --version
+          rustup +nightly show
+          cargo +nightly --version
+          bash --version
+          utils/${{ env.DEBIAN_CONTAINER_RUNNER }} utils/build-revive.sh -o ${{ env.REVIVE_DEBIAN_INSTALL}}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.REVIVE_DEBIAN_PACKAGE }}
+          path: ${{ env.REVIVE_DEBIAN_INSTALL }}/${{ env.REVIVE_DEBIAN_BINARY }}
+          retention-days: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 license = "MIT/Apache-2.0"
 edition = "2021"
 repository = "https://github.com/paritytech/revive"
+rust-version = "1.80.0"
 
 [workspace.dependencies]
 revive-benchmarks = { version = "0.1.0", path = "crates/benchmarks" }

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ install-bin:
 install-npm:
 	npm install && npm fund
 
+# install-revive: Build and install to the directory specified in REVIVE_INSTALL_DIR
+ifeq ($(origin REVIVE_INSTALL_DIR), undefined)
+REVIVE_INSTALL_DIR=`pwd`/release/revive-debian
+endif
+install-revive:
+	cargo install --path crates/solidity --root $(REVIVE_INSTALL_DIR)
+
 format:
 	cargo fmt --all --check
 

--- a/utils/build-debian-builder.sh
+++ b/utils/build-debian-builder.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+CONTAINER=revive-builder-debian-x86
+VERSION=latest
+DOCKERFILE=revive-builder-debian.dockerfile
+
+docker build --rm -t ${CONTAINER}:${VERSION} -f ${DOCKERFILE} $@

--- a/utils/build-revive.sh
+++ b/utils/build-revive.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+REVIVE_INSTALL_DIR=$(pwd)/target/release
+while getopts "o:" option ; do
+    case $option in
+    o) # Output directory
+        REVIVE_INSTALL_DIR=$OPTARG
+        ;;
+    \?) echo "Error: Invalid option"
+        exit 1;;
+    esac
+done
+echo "Installing to ${REVIVE_INSTALL_DIR}"
+
+$(pwd)/build-llvm.sh
+export PATH=$(pwd)/llvm18.0/bin:$PATH
+
+make install-revive REVIVE_INSTALL_DIR=${REVIVE_INSTALL_DIR}

--- a/utils/revive-builder-debian.dockerfile
+++ b/utils/revive-builder-debian.dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+# Dockerfile for building revive in a Debian container.
+FROM debian:12
+RUN <<EOF
+apt-get update
+apt-get install -q -y build-essential cmake make ninja-build python3 \
+    libmpfr-dev libgmp-dev libmpc-dev ncurses-dev \
+    git curl
+EOF
+ARG RUST_VERSION=stable
+RUN <<EOF
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION}
+EOF
+ENV PATH=/root/.cargo/bin:${PATH}

--- a/utils/run-debian-builder.sh
+++ b/utils/run-debian-builder.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+CONTAINER=revive-builder-debian-x86
+VERSION=latest
+
+docker run --rm -v $(pwd):$(pwd) -w $(pwd) ${CONTAINER}:${VERSION} $@


### PR DESCRIPTION
Makefile: Add target 'install-revive' to build revive with the installation path specified by variable REVIVE_INSTALL_DIR.

Add utils directory with scripts for building revive in a container.

Add utils/build-revive.sh taking option argument '-o <install-dir>' to build revive with the specified install directory.

Add utils/revive-builder-debian.dockerfile to make a docker container for building revive in a Debian environment.