### PR TITLE
implement immutable variables codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -898,7 +898,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "hash-db",
  "log",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1034,13 +1034,13 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1050,13 +1050,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1067,26 +1067,26 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "bp-polkadot"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1098,13 +1098,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1116,13 +1116,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1137,7 +1137,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "trie-db",
 ]
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1158,14 +1158,14 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1175,14 +1175,14 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1204,14 +1204,14 @@ dependencies = [
  "snowbridge-core",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1245,7 +1245,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -1254,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1276,7 +1276,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "staging-xcm",
  "tuplex",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1883,12 +1883,12 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "sp-version",
  "staging-xcm",
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -1938,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2032,17 +2032,17 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2748,15 +2748,15 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2809,7 +2809,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "array-bytes",
  "docify",
@@ -2842,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2866,7 +2866,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -2874,8 +2874,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "sp-weights",
  "static_assertions",
@@ -2885,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2917,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2939,7 +2939,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-version",
  "sp-weights",
 ]
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2961,7 +2961,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4127,7 +4127,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-alliance"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4243,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4272,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4303,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "aquamarine",
  "docify",
@@ -4354,13 +4354,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4394,7 +4394,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -4449,13 +4449,13 @@ dependencies = [
  "scale-info",
  "sp-consensus-grandpa",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -4467,14 +4467,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -4488,13 +4488,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -4512,13 +4512,13 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4536,7 +4536,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4554,7 +4554,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4573,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4604,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -4626,7 +4626,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4661,7 +4661,7 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -4671,7 +4671,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4726,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4826,7 +4826,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4844,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "blake2",
  "frame-benchmarking",
@@ -4862,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4884,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4900,7 +4900,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4919,7 +4919,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4935,7 +4935,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4961,7 +4961,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5033,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5050,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5081,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
@@ -5108,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5150,13 +5150,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5169,14 +5169,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5186,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5202,7 +5202,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5225,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5242,7 +5242,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5259,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5307,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5321,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5338,7 +5338,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5354,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -5377,7 +5377,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -5385,7 +5385,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "anyhow",
  "frame-system",
@@ -5402,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-mock-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5426,7 +5426,7 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -5436,7 +5436,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -5458,7 +5458,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5487,7 +5487,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5553,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5574,7 +5574,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5590,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5619,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5649,7 +5649,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5659,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5692,7 +5692,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5719,14 +5719,14 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5744,7 +5744,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5759,7 +5759,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5825,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5839,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5854,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5868,7 +5868,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -5905,7 +5905,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5923,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -5936,7 +5936,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -5945,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -5956,7 +5956,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -5964,7 +5964,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -5994,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -6014,7 +6014,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -6244,7 +6244,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6255,7 +6255,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -6271,7 +6271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -6292,13 +6292,13 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -6347,19 +6347,19 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bs58",
  "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -6399,7 +6399,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -6407,7 +6407,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -6598,11 +6598,11 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-core-hashing",
- "sp-crypto-ec-utils 0.10.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-crypto-ec-utils 0.10.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-crypto-hashing",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -6614,22 +6614,22 @@ dependencies = [
  "sp-npos-elections",
  "sp-offchain",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-session",
  "sp-staking",
  "sp-state-machine",
  "sp-statement-store",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-timestamp",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
  "sp-version",
  "sp-version-proc-macro",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-weights",
  "staging-parachain-info",
  "staging-xcm",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6667,7 +6667,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-transaction-pool",
  "sp-version",
 ]
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -7644,18 +7644,18 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -7665,25 +7665,25 @@ dependencies = [
  "schnellru",
  "sp-api",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "thiserror",
  "wasm-instrument",
 ]
@@ -7691,18 +7691,18 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "log",
  "polkavm 0.9.3",
  "sc-executor-common",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7712,8 +7712,8 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "wasmtime",
 ]
 
@@ -8074,7 +8074,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -8115,7 +8115,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "ssz_rs",
  "ssz_rs_derive",
 ]
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -8138,7 +8138,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -8146,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "ethabi-decode",
  "ethbloom 0.13.0",
@@ -8160,7 +8160,7 @@ dependencies = [
  "serde-big-array",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
@@ -8181,7 +8181,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8192,20 +8192,20 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "snowbridge-core",
  "snowbridge-outbound-queue-merkle-tree",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8222,26 +8222,26 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "static_assertions",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "alloy-primitives 0.4.2",
  "alloy-sol-types 0.4.2",
@@ -8260,7 +8260,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -8268,19 +8268,19 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -8296,13 +8296,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8314,7 +8314,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -8322,7 +8322,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-router-primitives"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -8333,7 +8333,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -8341,14 +8341,14 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-common"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "log",
  "parity-scale-codec",
  "snowbridge-core",
  "sp-arithmetic",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-test-common"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -8388,19 +8388,19 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
 ]
 
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "hash-db",
@@ -8409,10 +8409,10 @@ dependencies = [
  "scale-info",
  "sp-api-proc-macro",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-state-machine",
  "sp-trie",
  "sp-version",
@@ -8422,7 +8422,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "Inflector",
  "blake2",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8448,7 +8448,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -8480,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8492,7 +8492,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -8502,7 +8502,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8536,9 +8536,8 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
- "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -8557,7 +8556,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8574,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8585,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8596,7 +8595,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "array-bytes",
  "bandersnatch_vrfs",
@@ -8627,11 +8626,11 @@ dependencies = [
  "secrecy",
  "serde",
  "sp-crypto-hashing",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -8643,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "sp-crypto-hashing",
 ]
@@ -8651,7 +8650,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -8665,7 +8664,7 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
@@ -8691,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -8704,7 +8703,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -8714,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8734,11 +8733,11 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
@@ -8754,7 +8753,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8766,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -8779,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bytes",
  "docify",
@@ -8792,11 +8791,11 @@ dependencies = [
  "secp256k1",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-keystore",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-state-machine",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -8805,7 +8804,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -8815,18 +8814,18 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -8835,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -8845,7 +8844,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8856,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8865,7 +8864,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-core",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-runtime",
  "thiserror",
 ]
@@ -8873,7 +8872,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8886,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8896,18 +8895,18 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "backtrace",
- "lazy_static",
  "regex",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
+ "binary-merkle-tree",
  "docify",
  "either",
  "hash256-std-hasher",
@@ -8924,7 +8923,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-trie",
  "sp-weights",
  "tracing",
@@ -8933,19 +8932,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive 0.9.1",
  "primitive-types 0.12.2",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "static_assertions",
 ]
 
@@ -8971,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "Inflector",
  "expander",
@@ -8997,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9011,7 +9010,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9024,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "hash-db",
  "log",
@@ -9033,7 +9032,7 @@ dependencies = [
  "rand",
  "smallvec",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-panic-handler",
  "sp-trie",
  "thiserror",
@@ -9044,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -9058,9 +9057,9 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "thiserror",
  "x25519-dalek",
 ]
@@ -9068,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 
 [[package]]
 name = "sp-std"
@@ -9078,13 +9077,13 @@ source = "git+https://github.com/paritytech/polkadot-sdk#a5e40d0cd0a0d941d6fe58a
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
@@ -9102,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9114,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9136,7 +9135,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9145,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9159,11 +9158,10 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
- "lazy_static",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
@@ -9172,7 +9170,7 @@ dependencies = [
  "scale-info",
  "schnellru",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "thiserror",
  "tracing",
  "trie-db",
@@ -9182,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9191,7 +9189,7 @@ dependencies = [
  "serde",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -9199,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -9211,7 +9209,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9234,7 +9232,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -9242,7 +9240,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
 ]
 
 [[package]]
@@ -9321,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9334,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -9353,7 +9351,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9375,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9459,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -9471,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -9480,6 +9478,7 @@ dependencies = [
  "jobserver",
  "parity-wasm",
  "polkavm-linker 0.9.2",
+ "shlex",
  "sp-maybe-compressed-blob",
  "strum 0.26.3",
  "tempfile",
@@ -9589,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "testnet-parachains-constants"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10381,7 +10380,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -10695,7 +10694,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -10706,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -10720,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53#c77095f51119d2eccdc54d2f3518bed0ffbd6d53"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2#fe0bfb79f4c883abbc3214519d19e46617c20bd2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10733,7 +10732,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=c77095f51119d2eccdc54d2f3518bed0ffbd6d53)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=fe0bfb79f4c883abbc3214519d19e46617c20bd2)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7393,6 +7393,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "inkwell",
+ "revive-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ log = { version = "0.4" }
 # polkadot-sdk and friends
 codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }
 scale-info = { version = "2.11.1", default-features = false }
-polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", rev = "c77095f51119d2eccdc54d2f3518bed0ffbd6d53" }
+polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", rev = "fe0bfb79f4c883abbc3214519d19e46617c20bd2" }
 
 # llvm
 [workspace.dependencies.inkwell]

--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,10 +1,10 @@
 {
-  "Baseline": 912,
-  "Computation": 4413,
-  "DivisionArithmetics": 40689,
-  "ERC20": 54374,
-  "Events": 1726,
-  "FibonacciIterative": 3015,
-  "Flipper": 3612,
-  "SHA1": 32865
+  "Baseline": 962,
+  "Computation": 4463,
+  "DivisionArithmetics": 40756,
+  "ERC20": 54427,
+  "Events": 1792,
+  "FibonacciIterative": 3065,
+  "Flipper": 3665,
+  "SHA1": 32923
 }

--- a/crates/integration/contracts/Immutables.sol
+++ b/crates/integration/contracts/Immutables.sol
@@ -6,37 +6,21 @@ pragma solidity ^0.8;
   "differential": true,
   "actions": [
     {
+      "Upload": {
+        "code": {
+          "Solidity": {
+            "contract": "ImmutablesTester"
+          }
+        }
+      }
+    },
+    {
       "Instantiate": {
-	    "code": {
-		  "Solidity": {
-		    "contract": "Immutables"
-		  }
-		},
-        "data": "000000000000000000000000000000000000000000000000000000000000007b"
-      }
-    },
-    {
-      "Call": {
-        "dest": {
-          "Instantiated": 0
-        },
-        "data": "c2985578"
-      }
-    },
-    {
-      "Call": {
-        "dest": {
-          "Instantiated": 0
-        },
-        "data": "febb0f7e"
-      }
-    },
-    {
-      "Call": {
-        "dest": {
-          "Instantiated": 0
-        },
-        "data": "7b6a8777"
+        "code": {
+          "Solidity": {
+            "contract": "Immutables"
+          }
+        }
       }
     },
     {
@@ -50,20 +34,30 @@ pragma solidity ^0.8;
 }
 */
 
-contract Immutables {
+contract ImmutablesTester {
+    // Read should work in the runtime code
     uint public immutable foo;
+    // Read should work in the runtime code
     uint public immutable bar;
+    // Read should work in the runtime code
     uint public immutable zoo;
 
+    // Assign and read should work in the constructor
     constructor(uint _foo) payable {
         foo = _foo;
         bar = foo + 1;
         zoo = bar + 2;
-    }
 
+        assert(zoo == _foo + 3);
+    }
+}
+
+contract Immutables {
     fallback() external {
-        assert(foo > 0);
-        assert(bar == foo + 1);
-        assert(zoo == bar + 2);
+        ImmutablesTester tester = new ImmutablesTester(127);
+
+        assert(tester.foo() == 127);
+        assert(tester.bar() == tester.foo() + 1);
+        assert(tester.zoo() == tester.bar() + 2);
     }
 }

--- a/crates/integration/contracts/Immutables.sol
+++ b/crates/integration/contracts/Immutables.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8;
+
+/* runner.json
+{
+  "differential": true,
+  "actions": [
+    {
+      "Instantiate": {
+	    "code": {
+		  "Solidity": {
+		    "contract": "Immutables"
+		  }
+		},
+        "data": "000000000000000000000000000000000000000000000000000000000000007b"
+      }
+    },
+    {
+      "Call": {
+        "dest": {
+          "Instantiated": 0
+        },
+        "data": "c2985578"
+      }
+    },
+    {
+      "Call": {
+        "dest": {
+          "Instantiated": 0
+        },
+        "data": "febb0f7e"
+      }
+    },
+    {
+      "Call": {
+        "dest": {
+          "Instantiated": 0
+        },
+        "data": "7b6a8777"
+      }
+    },
+    {
+      "Call": {
+        "dest": {
+          "Instantiated": 0
+        }
+      }
+    }
+  ]
+}
+*/
+
+contract Immutables {
+    uint public immutable foo;
+    uint public immutable bar;
+    uint public immutable zoo;
+
+    constructor(uint _foo) payable {
+        foo = _foo;
+        bar = foo + 1;
+        zoo = bar + 2;
+    }
+
+    fallback() external {
+        assert(foo > 0);
+        assert(bar > 0);
+        assert(zoo > 0);
+    }
+}

--- a/crates/integration/contracts/Immutables.sol
+++ b/crates/integration/contracts/Immutables.sol
@@ -63,7 +63,7 @@ contract Immutables {
 
     fallback() external {
         assert(foo > 0);
-        assert(bar > 0);
-        assert(zoo > 0);
+        assert(bar == foo + 1);
+        assert(zoo == bar + 2);
     }
 }

--- a/crates/integration/src/tests.rs
+++ b/crates/integration/src/tests.rs
@@ -42,6 +42,7 @@ test_spec!(create, "CreateB", "Create.sol");
 test_spec!(call, "Caller", "Call.sol");
 test_spec!(transfer, "Transfer", "Transfer.sol");
 test_spec!(return_data_oob, "ReturnDataOob", "ReturnDataOob.sol");
+test_spec!(immutables, "Immutables", "Immutables.sol");
 
 fn instantiate(path: &str, contract: &str) -> Vec<SpecsAction> {
     vec![Instantiate {

--- a/crates/llvm-context/src/lib.rs
+++ b/crates/llvm-context/src/lib.rs
@@ -27,9 +27,11 @@ pub use self::polkavm::context::function::llvm_runtime::LLVMRuntime as PolkaVMLL
 pub use self::polkavm::context::function::r#return::Return as PolkaVMFunctionReturn;
 pub use self::polkavm::context::function::runtime::deploy_code::DeployCode as PolkaVMDeployCodeFunction;
 pub use self::polkavm::context::function::runtime::entry::Entry as PolkaVMEntryFunction;
+pub use self::polkavm::context::function::runtime::immutable_data_load::ImmutableDataLoad as PolkaVMImmutableDataLoadFunction;
 pub use self::polkavm::context::function::runtime::runtime_code::RuntimeCode as PolkaVMRuntimeCodeFunction;
 pub use self::polkavm::context::function::runtime::FUNCTION_DEPLOY_CODE as PolkaVMFunctionDeployCode;
 pub use self::polkavm::context::function::runtime::FUNCTION_ENTRY as PolkaVMFunctionEntry;
+pub use self::polkavm::context::function::runtime::FUNCTION_LOAD_IMMUTABLE_DATA as PolkaVMFunctionImmutableDataLoad;
 pub use self::polkavm::context::function::runtime::FUNCTION_RUNTIME_CODE as PolkaVMFunctionRuntimeCode;
 pub use self::polkavm::context::function::yul_data::YulData as PolkaVMFunctionYulData;
 pub use self::polkavm::context::function::Function as PolkaVMFunction;

--- a/crates/llvm-context/src/polkavm/const/runtime_api.rs
+++ b/crates/llvm-context/src/polkavm/const/runtime_api.rs
@@ -29,6 +29,8 @@ pub mod imports {
 
     pub static DEPOSIT_EVENT: &str = "deposit_event";
 
+    pub static GET_IMMUTABLE_DATA: &str = "get_immutable_data";
+
     pub static GET_STORAGE: &str = "get_storage";
 
     pub static HASH_KECCAK_256: &str = "hash_keccak_256";
@@ -47,11 +49,13 @@ pub mod imports {
 
     pub static SET_STORAGE: &str = "set_storage";
 
+    pub static SET_IMMUTABLE_DATA: &str = "set_immutable_data";
+
     pub static VALUE_TRANSFERRED: &str = "value_transferred";
 
     /// All imported runtime API symbols.
     /// Useful for configuring common attributes and linkage.
-    pub static IMPORTS: [&str; 18] = [
+    pub static IMPORTS: [&str; 20] = [
         ADDRESS,
         BALANCE,
         BLOCK_NUMBER,
@@ -60,6 +64,7 @@ pub mod imports {
         CHAIN_ID,
         CODE_SIZE,
         DEPOSIT_EVENT,
+        GET_IMMUTABLE_DATA,
         GET_STORAGE,
         HASH_KECCAK_256,
         INPUT,
@@ -68,6 +73,7 @@ pub mod imports {
         RETURN,
         RETURNDATACOPY,
         RETURNDATASIZE,
+        SET_IMMUTABLE_DATA,
         SET_STORAGE,
         VALUE_TRANSFERRED,
     ];

--- a/crates/llvm-context/src/polkavm/context/function/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/function/mod.rs
@@ -91,7 +91,8 @@ impl<'ctx> Function<'ctx> {
             || (name.starts_with("__")
                 && name != self::runtime::FUNCTION_ENTRY
                 && name != self::runtime::FUNCTION_DEPLOY_CODE
-                && name != self::runtime::FUNCTION_RUNTIME_CODE)
+                && name != self::runtime::FUNCTION_RUNTIME_CODE
+                && name != self::runtime::FUNCTION_LOAD_IMMUTABLE_DATA)
     }
 
     /// Checks whether the function is related to the near call ABI.

--- a/crates/llvm-context/src/polkavm/context/function/runtime/entry.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/entry.rs
@@ -31,6 +31,18 @@ impl Entry {
     where
         D: Dependency + Clone,
     {
+        context.declare_global(
+            revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_POINTER,
+            context.word_type().array_type(0),
+            AddressSpace::Stack,
+        );
+
+        context.declare_global(
+            revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_SIZE,
+            context.xlen_type(),
+            AddressSpace::Stack,
+        );
+
         let calldata_type = context.array_type(context.byte_type(), Self::MAX_CALLDATA_SIZE);
         context.set_global(
             crate::polkavm::GLOBAL_CALLDATA_POINTER,

--- a/crates/llvm-context/src/polkavm/context/function/runtime/immutable_data_load.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/immutable_data_load.rs
@@ -1,0 +1,116 @@
+//! The immutable data runtime function.
+
+use crate::polkavm::context::address_space::AddressSpace;
+use crate::polkavm::context::function::runtime;
+use crate::polkavm::context::pointer::Pointer;
+use crate::polkavm::context::Context;
+use crate::polkavm::WriteLLVM;
+use crate::polkavm::{runtime_api, Dependency};
+
+/// A function for requesting the immutable data from the runtime.
+/// This is a special function that is only used by the front-end generated code.
+///
+/// The runtime API is called lazily and subsequent calls are no-ops.
+///
+/// The bytes written is asserted to match the expected length.
+/// This should never fail; the length is known.
+/// However, this is a one time assertion, hence worth it.
+#[derive(Debug)]
+pub struct ImmutableDataLoad;
+
+impl<D> WriteLLVM<D> for ImmutableDataLoad
+where
+    D: Dependency + Clone,
+{
+    fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
+        context.add_function(
+            runtime::FUNCTION_LOAD_IMMUTABLE_DATA,
+            context.void_type().fn_type(Default::default(), false),
+            0,
+            Some(inkwell::module::Linkage::Private),
+        )?;
+
+        Ok(())
+    }
+
+    fn into_llvm(self, context: &mut Context<D>) -> anyhow::Result<()> {
+        context.set_current_function(runtime::FUNCTION_LOAD_IMMUTABLE_DATA)?;
+        context.set_basic_block(context.current_function().borrow().entry_block());
+
+        let immutable_data_size_pointer = context
+            .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_SIZE)?
+            .value
+            .as_pointer_value();
+        let immutable_data_size = context.build_load(
+            Pointer::new(
+                context.xlen_type(),
+                AddressSpace::Stack,
+                immutable_data_size_pointer,
+            ),
+            "immutable_data_size_load",
+        )?;
+
+        let load_immutable_data_block = context.append_basic_block("load_immutables_block");
+        let return_block = context.current_function().borrow().return_block();
+        let immutable_data_size_is_zero = context.builder().build_int_compare(
+            inkwell::IntPredicate::EQ,
+            context.xlen_type().const_zero(),
+            immutable_data_size.into_int_value(),
+            "immutable_data_size_is_zero",
+        )?;
+        context.build_conditional_branch(
+            immutable_data_size_is_zero,
+            return_block,
+            load_immutable_data_block,
+        )?;
+
+        context.set_basic_block(load_immutable_data_block);
+        let output_pointer = context
+            .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_POINTER)?
+            .value
+            .as_pointer_value();
+        context.build_runtime_call(
+            runtime_api::imports::GET_IMMUTABLE_DATA,
+            &[
+                context
+                    .builder()
+                    .build_ptr_to_int(output_pointer, context.xlen_type(), "ptr_to_xlen")?
+                    .into(),
+                context
+                    .builder()
+                    .build_ptr_to_int(
+                        immutable_data_size_pointer,
+                        context.xlen_type(),
+                        "ptr_to_xlen",
+                    )?
+                    .into(),
+            ],
+        );
+        let bytes_written = context.builder().build_load(
+            context.xlen_type(),
+            immutable_data_size_pointer,
+            "bytes_written",
+        )?;
+        context.builder().build_store(
+            immutable_data_size_pointer,
+            context.xlen_type().const_zero(),
+        )?;
+        let overflow_block = context.append_basic_block("immutable_data_overflow");
+        let is_overflow = context.builder().build_int_compare(
+            inkwell::IntPredicate::UGT,
+            immutable_data_size.into_int_value(),
+            bytes_written.into_int_value(),
+            "is_overflow",
+        )?;
+        context.build_conditional_branch(is_overflow, overflow_block, return_block)?;
+
+        context.set_basic_block(overflow_block);
+        context.build_call(context.intrinsics().trap, &[], "invalid_trap");
+        context.build_unreachable();
+
+        context.set_basic_block(return_block);
+        context.build_return(None);
+
+        Ok(())
+    }
+}

--- a/crates/llvm-context/src/polkavm/context/function/runtime/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod deploy_code;
 pub mod entry;
+pub mod immutable_data_load;
 pub mod runtime_code;
 
 /// The main entry function name.
@@ -12,3 +13,6 @@ pub const FUNCTION_DEPLOY_CODE: &str = "__deploy";
 
 /// The runtime code function name.
 pub const FUNCTION_RUNTIME_CODE: &str = "__runtime";
+
+/// The immutable data load function name.
+pub const FUNCTION_LOAD_IMMUTABLE_DATA: &str = "__immutable_data_load";

--- a/crates/llvm-context/src/polkavm/context/global.rs
+++ b/crates/llvm-context/src/polkavm/context/global.rs
@@ -51,4 +51,31 @@ impl<'ctx> Global<'ctx> {
 
         global
     }
+
+    /// Construct an external global.
+    pub fn declare<D, T>(
+        context: &mut Context<'ctx, D>,
+        r#type: T,
+        address_space: AddressSpace,
+        name: &str,
+    ) -> Self
+    where
+        D: PolkaVMDependency + Clone,
+        T: BasicType<'ctx>,
+    {
+        let r#type = r#type.as_basic_type_enum();
+
+        let value = context
+            .module()
+            .add_global(r#type, Some(address_space.into()), name);
+        let global = Self { r#type, value };
+
+        global.value.set_linkage(inkwell::module::Linkage::External);
+        global
+            .value
+            .set_visibility(inkwell::GlobalVisibility::Default);
+        global.value.set_externally_initialized(true);
+
+        global
+    }
 }

--- a/crates/llvm-context/src/polkavm/context/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/mod.rs
@@ -162,6 +162,18 @@ where
         })
     }
 
+    fn link_immutable_data(&self, contract_path: &str) -> anyhow::Result<()> {
+        let size = self.solidity().immutables_size() as u32;
+        let exports = revive_runtime_api::immutable_data::module(self.llvm(), size);
+        self.module.link_in_module(exports).map_err(|error| {
+            anyhow::anyhow!(
+                "The contract `{}` immutable data module linking error: {}",
+                contract_path,
+                error
+            )
+        })
+    }
+
     /// Configure the PolkaVM minimum stack size.
     fn set_polkavm_stack_size(
         llvm: &'ctx inkwell::context::Context,
@@ -239,6 +251,7 @@ where
         let module_clone = self.module.clone();
 
         self.link_polkavm_exports(contract_path)?;
+        self.link_immutable_data(contract_path)?;
 
         let target_machine = TargetMachine::new(Target::PVM, self.optimizer.settings())?;
         target_machine.set_target_data(self.module());
@@ -379,6 +392,15 @@ where
                 self.globals.insert(name.to_owned(), global);
             }
         }
+    }
+
+    /// Declare an external global.
+    pub fn declare_global<T>(&mut self, name: &str, r#type: T, address_space: AddressSpace)
+    where
+        T: BasicType<'ctx> + Clone + Copy,
+    {
+        let global = Global::declare(self, r#type, address_space, name);
+        self.globals.insert(name.to_owned(), global);
     }
 
     /// Returns the LLVM intrinsics collection reference.

--- a/crates/llvm-context/src/polkavm/context/solidity_data.rs
+++ b/crates/llvm-context/src/polkavm/context/solidity_data.rs
@@ -17,7 +17,7 @@ impl SolidityData {
         Self::default()
     }
 
-    /// Returns the current number of immutables values in the contract.
+    /// Returns the current size of immutable values in the contract.
     pub fn immutables_size(&self) -> usize {
         self.immutables.len() * revive_common::BYTE_LENGTH_WORD
     }

--- a/crates/llvm-context/src/polkavm/evm/immutable.rs
+++ b/crates/llvm-context/src/polkavm/evm/immutable.rs
@@ -1,14 +1,18 @@
 //! Translates the contract immutable operations.
 
+use inkwell::types::BasicType;
+
 use crate::polkavm::context::address_space::AddressSpace;
 use crate::polkavm::context::code_type::CodeType;
 use crate::polkavm::context::pointer::Pointer;
 use crate::polkavm::context::Context;
-use crate::polkavm::Dependency;
+use crate::polkavm::{runtime_api, Dependency};
 
 /// Translates the contract immutable load.
-/// In the deploy code the values are read from the auxiliary heap.
-/// In the runtime code they are requested from the system contract.
+///
+/// In deploy code the values are read from the stack.
+///
+/// In runtime code they are loaded lazily with the `get_immutable_data` syscall.
 pub fn load<'ctx, D>(
     context: &mut Context<'ctx, D>,
     index: inkwell::values::IntValue<'ctx>,
@@ -20,38 +24,75 @@ where
         None => {
             anyhow::bail!("Immutables are not available if the contract part is undefined");
         }
-        Some(CodeType::Deploy) => {
-            let index_double = context.builder().build_int_mul(
-                index,
-                context.word_const(2),
-                "immutable_load_index_double",
-            )?;
-            let offset_absolute = context.builder().build_int_add(
-                index_double,
-                context.word_const(
-                    crate::polkavm::HEAP_AUX_OFFSET_CONSTRUCTOR_RETURN_DATA
-                        + (3 * revive_common::BYTE_LENGTH_WORD) as u64,
-                ),
-                "immutable_offset_absolute",
-            )?;
-            let immutable_pointer = Pointer::new_with_offset(
-                context,
-                AddressSpace::default(),
-                context.word_type(),
-                offset_absolute,
-                "immutable_pointer",
-            );
-            context.build_load(immutable_pointer, "immutable_value")
-        }
+        Some(CodeType::Deploy) => load_from_memory(context, index),
         Some(CodeType::Runtime) => {
-            todo!()
+            let immutable_data_size_pointer = context
+                .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_SIZE)?
+                .value
+                .as_pointer_value();
+            let immutable_data_size = context.build_load(
+                Pointer::new(
+                    context.xlen_type(),
+                    AddressSpace::Stack,
+                    immutable_data_size_pointer,
+                ),
+                "immutable_data_size_load",
+            )?;
+
+            let load_immutable_data_block = context.append_basic_block("load_immutables_block");
+            let join_load_block = context.append_basic_block("join_load_block");
+            let immutable_data_size_is_zero = context.builder().build_int_compare(
+                inkwell::IntPredicate::EQ,
+                context.xlen_type().const_zero(),
+                immutable_data_size.into_int_value(),
+                "immutable_data_size_is_zero",
+            )?;
+            context.build_conditional_branch(
+                immutable_data_size_is_zero,
+                join_load_block,
+                load_immutable_data_block,
+            )?;
+
+            context.set_basic_block(load_immutable_data_block);
+            let output_pointer = context
+                .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_POINTER)?
+                .value
+                .as_pointer_value();
+            context.build_runtime_call(
+                runtime_api::imports::GET_IMMUTABLE_DATA,
+                &[
+                    context
+                        .builder()
+                        .build_ptr_to_int(output_pointer, context.xlen_type(), "ptr_to_xlen")?
+                        .into(),
+                    context
+                        .builder()
+                        .build_ptr_to_int(
+                            immutable_data_size_pointer,
+                            context.xlen_type(),
+                            "ptr_to_xlen",
+                        )?
+                        .into(),
+                ],
+            );
+            // todo: check out length
+            context.builder().build_store(
+                immutable_data_size_pointer,
+                context.xlen_type().const_zero(),
+            )?;
+            context.build_unconditional_branch(join_load_block);
+
+            context.set_basic_block(join_load_block);
+            load_from_memory(context, index)
         }
     }
 }
 
 /// Translates the contract immutable store.
-/// In the deploy code the values are written to the auxiliary heap at the predefined offset,
-/// being prepared for returning to the system contract for saving.
+///
+/// In deploy code the values are written to the stack at the predefined offset,
+/// being prepared for storing them using the `set_immutable_data` syscall.
+///
 /// Ignored in the runtime code.
 pub fn store<'ctx, D>(
     context: &mut Context<'ctx, D>,
@@ -66,46 +107,48 @@ where
             anyhow::bail!("Immutables are not available if the contract part is undefined");
         }
         Some(CodeType::Deploy) => {
-            let index_double = context.builder().build_int_mul(
-                index,
-                context.word_const(2),
-                "immutable_load_index_double",
-            )?;
-            let index_offset_absolute = context.builder().build_int_add(
-                index_double,
-                context.word_const(
-                    crate::polkavm::HEAP_AUX_OFFSET_CONSTRUCTOR_RETURN_DATA
-                        + (2 * revive_common::BYTE_LENGTH_WORD) as u64,
+            let immutable_data_pointer = context
+                .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_POINTER)?
+                .value
+                .as_pointer_value();
+            let immutable_pointer = context.build_gep(
+                Pointer::new(
+                    context.word_type(),
+                    AddressSpace::Stack,
+                    immutable_data_pointer,
                 ),
-                "index_offset_absolute",
-            )?;
-            let index_offset_pointer = Pointer::new_with_offset(
-                context,
-                AddressSpace::default(),
-                context.word_type(),
-                index_offset_absolute,
-                "immutable_index_pointer",
+                &[index],
+                context.word_type().as_basic_type_enum(),
+                "immutable_variable_pointer",
             );
-            context.build_store(index_offset_pointer, index)?;
-
-            let value_offset_absolute = context.builder().build_int_add(
-                index_offset_absolute,
-                context.word_const(revive_common::BYTE_LENGTH_WORD as u64),
-                "value_offset_absolute",
-            )?;
-            let value_offset_pointer = Pointer::new_with_offset(
-                context,
-                AddressSpace::default(),
-                context.word_type(),
-                value_offset_absolute,
-                "immutable_value_pointer",
-            );
-            context.build_store(value_offset_pointer, value)?;
-
-            Ok(())
+            context.build_store(immutable_pointer, value)
         }
         Some(CodeType::Runtime) => {
             anyhow::bail!("Immutable writes are not available in the runtime code");
         }
     }
+}
+
+pub fn load_from_memory<'ctx, D>(
+    context: &mut Context<'ctx, D>,
+    index: inkwell::values::IntValue<'ctx>,
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
+where
+    D: Dependency + Clone,
+{
+    let immutable_data_pointer = context
+        .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_POINTER)?
+        .value
+        .as_pointer_value();
+    let immutable_pointer = context.build_gep(
+        Pointer::new(
+            context.word_type(),
+            AddressSpace::Stack,
+            immutable_data_pointer,
+        ),
+        &[index],
+        context.word_type().as_basic_type_enum(),
+        "immutable_variable_pointer",
+    );
+    context.build_load(immutable_pointer, "immutable_value")
 }

--- a/crates/llvm-context/src/polkavm/evm/return.rs
+++ b/crates/llvm-context/src/polkavm/evm/return.rs
@@ -1,7 +1,10 @@
 //! Translates the transaction return operations.
 
+use crate::polkavm::context::address_space::AddressSpace;
+use crate::polkavm::context::code_type::CodeType;
+use crate::polkavm::context::pointer::Pointer;
 use crate::polkavm::context::Context;
-use crate::polkavm::Dependency;
+use crate::polkavm::{runtime_api, Dependency};
 
 /// Translates the `return` instruction.
 pub fn r#return<'ctx, D>(
@@ -12,8 +15,60 @@ pub fn r#return<'ctx, D>(
 where
     D: Dependency + Clone,
 {
-    if context.code_type().is_none() {
-        anyhow::bail!("Return is not available if the contract part is undefined");
+    match context.code_type() {
+        None => anyhow::bail!("Return is not available if the contract part is undefined"),
+        Some(CodeType::Deploy) => {
+            let immutable_data_size_pointer = context
+                .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_SIZE)?
+                .value
+                .as_pointer_value();
+            let immutable_data_size = context.build_load(
+                Pointer::new(
+                    context.xlen_type(),
+                    AddressSpace::Stack,
+                    immutable_data_size_pointer,
+                ),
+                "immutable_data_size_load",
+            )?;
+
+            let write_immutable_data_block = context.append_basic_block("write_immutables_block");
+            let join_return_block = context.append_basic_block("join_return_block");
+            let immutable_data_size_is_zero = context.builder().build_int_compare(
+                inkwell::IntPredicate::EQ,
+                context.xlen_type().const_zero(),
+                immutable_data_size.into_int_value(),
+                "immutable_data_size_is_zero",
+            )?;
+            context.build_conditional_branch(
+                immutable_data_size_is_zero,
+                join_return_block,
+                write_immutable_data_block,
+            )?;
+
+            context.set_basic_block(write_immutable_data_block);
+            let immutable_data_pointer = context
+                .get_global(revive_runtime_api::immutable_data::GLOBAL_IMMUTABLE_DATA_POINTER)?
+                .value
+                .as_pointer_value();
+            context.build_runtime_call(
+                runtime_api::imports::SET_IMMUTABLE_DATA,
+                &[
+                    context
+                        .builder()
+                        .build_ptr_to_int(
+                            immutable_data_pointer,
+                            context.xlen_type(),
+                            "immutable_data_pointer_to_xlen",
+                        )?
+                        .into(),
+                    immutable_data_size.into(),
+                ],
+            );
+            context.build_unconditional_branch(join_return_block);
+
+            context.set_basic_block(join_return_block);
+        }
+        Some(CodeType::Runtime) => {}
     }
 
     context.build_exit(

--- a/crates/llvm-context/src/polkavm/evm/return.rs
+++ b/crates/llvm-context/src/polkavm/evm/return.rs
@@ -61,7 +61,7 @@ where
                             "immutable_data_pointer_to_xlen",
                         )?
                         .into(),
-                    immutable_data_size.into(),
+                    immutable_data_size,
                 ],
             );
             context.build_unconditional_branch(join_return_block);

--- a/crates/runtime-api/Cargo.toml
+++ b/crates/runtime-api/Cargo.toml
@@ -13,3 +13,5 @@ riscv-64 = []
 [dependencies]
 anyhow = { workspace = true }
 inkwell = { workspace = true, features = ["target-riscv", "no-libffi-linking", "llvm18-0"] }
+
+revive-common = { workspace = true }

--- a/crates/runtime-api/src/immutable_data.rs
+++ b/crates/runtime-api/src/immutable_data.rs
@@ -1,0 +1,94 @@
+//! Allocates memory for the immutable data in a separate module.
+//!
+//! Because we only know how many immutable variables were set after
+//! translating the whole contract code, we want to set the size at
+//! last. However, array types need a size upon declaration.
+//!
+//! A simple work around is to replace it during link time.
+//! To quote the [LLVM docs][0]:
+//!
+//! > For global variable declarations [..] the allocation size and
+//! > alignment of the definition it resolves to must be greater than
+//! > or equal to that of the declaration [..]
+//!
+//! To adhere to this we initially declare a length of 0 in
+//! `revive-llvm-context`.
+//!
+//! [0]: https://llvm.org/docs/LangRef.html#global-variables
+
+/// The immutable data module name.
+pub static MODULE_NAME: &str = "__evm_immutables";
+/// The immutable data global pointer.
+pub static GLOBAL_IMMUTABLE_DATA_POINTER: &str = "__immutable_data_ptr";
+/// The immutable data global size.
+pub static GLOBAL_IMMUTABLE_DATA_SIZE: &str = "__immutable_data_size";
+/// The immutable data maximum size in bytes.
+pub static IMMUTABLE_DATA_MAX_SIZE: u32 = 4 * 1024;
+
+/// Returns the immutable data global type.
+pub fn data_type<'context>(
+    context: &'context inkwell::context::Context,
+    size: u32,
+) -> inkwell::types::ArrayType<'context> {
+    context.custom_width_int_type(256).array_type(size)
+}
+
+/// Returns the immutable data size global type.
+pub fn size_type<'context>(
+    context: &'context inkwell::context::Context,
+) -> inkwell::types::IntType<'context> {
+    context.i32_type()
+}
+
+/// Creates a LLVM module with the immutable data and its `size` in bytes (the length).
+pub fn module<'context>(
+    context: &'context inkwell::context::Context,
+    size: u32,
+) -> inkwell::module::Module<'context> {
+    let module = context.create_module(MODULE_NAME);
+
+    let immutable_data = module.add_global(
+        data_type(context, size / 32),
+        Default::default(),
+        GLOBAL_IMMUTABLE_DATA_POINTER,
+    );
+    immutable_data.set_linkage(inkwell::module::Linkage::External);
+    immutable_data.set_visibility(inkwell::GlobalVisibility::Default);
+    immutable_data.set_initializer(&data_type(context, size / 32).get_undef());
+
+    let immutable_data_size = module.add_global(
+        size_type(context),
+        Default::default(),
+        GLOBAL_IMMUTABLE_DATA_SIZE,
+    );
+    immutable_data_size.set_linkage(inkwell::module::Linkage::External);
+    immutable_data_size.set_visibility(inkwell::GlobalVisibility::Default);
+    immutable_data_size.set_initializer(&size_type(context).const_int(size as u64, false));
+
+    module
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::immutable_data::*;
+
+    #[test]
+    fn it_works() {
+        inkwell::targets::Target::initialize_riscv(&Default::default());
+        let context = inkwell::context::Context::create();
+        let size = 512;
+        let module = crate::immutable_data::module(&context, size);
+
+        let immutable_data_pointer = module.get_global(GLOBAL_IMMUTABLE_DATA_POINTER).unwrap();
+        assert_eq!(
+            immutable_data_pointer.get_initializer().unwrap(),
+            data_type(&context, size / 32).get_undef()
+        );
+
+        let immutable_data_size = module.get_global(GLOBAL_IMMUTABLE_DATA_SIZE).unwrap();
+        assert_eq!(
+            immutable_data_size.get_initializer().unwrap(),
+            size_type(&context).const_int(size as u64, false)
+        );
+    }
+}

--- a/crates/runtime-api/src/lib.rs
+++ b/crates/runtime-api/src/lib.rs
@@ -7,5 +7,6 @@
 //! [1]: [https://docs.rs/pallet-contracts/26.0.0/pallet_contracts/api_doc/index.html]
 
 pub mod calling_convention;
+pub mod immutable_data;
 pub mod polkavm_exports;
 pub mod polkavm_imports;

--- a/crates/runtime-api/src/polkavm_imports.c
+++ b/crates/runtime-api/src/polkavm_imports.c
@@ -59,6 +59,10 @@ POLKAVM_IMPORT(void, return_data_copy, uint32_t, uint32_t, uint32_t)
 
 POLKAVM_IMPORT(void, return_data_size, uint32_t)
 
+POLKAVM_IMPORT(void, set_immutable_data, uint32_t, uint32_t);
+
+POLKAVM_IMPORT(void, get_immutable_data, uint32_t, uint32_t);
+
 POLKAVM_IMPORT(void, value_transferred, uint32_t)
 
 POLKAVM_IMPORT(uint32_t, set_storage, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t)

--- a/crates/solidity/src/evmla/assembly/mod.rs
+++ b/crates/solidity/src/evmla/assembly/mod.rs
@@ -199,6 +199,7 @@ where
             revive_llvm_context::PolkaVMDummyLLVMWritable::default(),
         )
         .declare(context)?;
+        revive_llvm_context::PolkaVMImmutableDataLoadFunction.declare(context)?;
 
         entry.into_llvm(context)?;
 
@@ -266,6 +267,7 @@ where
             revive_llvm_context::PolkaVMCodeType::Runtime,
         ))
         .into_llvm(context)?;
+        revive_llvm_context::PolkaVMImmutableDataLoadFunction.into_llvm(context)?;
 
         Ok(())
     }

--- a/crates/solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/crates/solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -767,7 +767,7 @@ where
                     .get_or_allocate_immutable(key.as_str())
                     / revive_common::BYTE_LENGTH_WORD;
 
-                let index = context.word_const(offset as u64);
+                let index = context.xlen_type().const_int(offset as u64, false);
                 revive_llvm_context::polkavm_evm_immutable::load(context, index).map(Some)
             }
             InstructionName::ASSIGNIMMUTABLE => {
@@ -781,7 +781,7 @@ where
                 let offset = context.solidity_mut().allocate_immutable(key.as_str())
                     / revive_common::BYTE_LENGTH_WORD;
 
-                let index = context.word_const(offset as u64);
+                let index = context.xlen_type().const_int(offset as u64, false);
                 let value = arguments.pop().expect("Always exists").into_int_value();
                 revive_llvm_context::polkavm_evm_immutable::store(context, index, value)
                     .map(|_| None)

--- a/crates/solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
+++ b/crates/solidity/src/evmla/ethereal_ir/function/block/element/mod.rs
@@ -45,7 +45,7 @@ impl Element {
     fn pop_arguments_llvm<'ctx, D>(
         &mut self,
         context: &mut revive_llvm_context::PolkaVMContext<'ctx, D>,
-    ) -> Vec<inkwell::values::BasicValueEnum<'ctx>>
+    ) -> anyhow::Result<Vec<inkwell::values::BasicValueEnum<'ctx>>>
     where
         D: revive_llvm_context::PolkaVMDependency + Clone,
     {
@@ -57,15 +57,13 @@ impl Element {
                 [self.stack.elements.len() + input_size - output_size - 1 - index]
                 .to_llvm()
                 .into_pointer_value();
-            let value = context
-                .build_load(
-                    revive_llvm_context::PolkaVMPointer::new_stack_field(context, pointer),
-                    format!("argument_{index}").as_str(),
-                )
-                .unwrap();
+            let value = context.build_load(
+                revive_llvm_context::PolkaVMPointer::new_stack_field(context, pointer),
+                format!("argument_{index}").as_str(),
+            )?;
             arguments.push(value);
         }
-        arguments
+        Ok(arguments)
     }
 }
 
@@ -426,7 +424,7 @@ where
             InstructionName::JUMPDEST => Ok(None),
 
             InstructionName::ADD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::addition(
                     context,
                     arguments[0].into_int_value(),
@@ -435,7 +433,7 @@ where
                 .map(Some)
             }
             InstructionName::SUB => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::subtraction(
                     context,
                     arguments[0].into_int_value(),
@@ -444,7 +442,7 @@ where
                 .map(Some)
             }
             InstructionName::MUL => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::multiplication(
                     context,
                     arguments[0].into_int_value(),
@@ -453,7 +451,7 @@ where
                 .map(Some)
             }
             InstructionName::DIV => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::division(
                     context,
                     arguments[0].into_int_value(),
@@ -462,7 +460,7 @@ where
                 .map(Some)
             }
             InstructionName::MOD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::remainder(
                     context,
                     arguments[0].into_int_value(),
@@ -471,7 +469,7 @@ where
                 .map(Some)
             }
             InstructionName::SDIV => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::division_signed(
                     context,
                     arguments[0].into_int_value(),
@@ -480,7 +478,7 @@ where
                 .map(Some)
             }
             InstructionName::SMOD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_arithmetic::remainder_signed(
                     context,
                     arguments[0].into_int_value(),
@@ -490,7 +488,7 @@ where
             }
 
             InstructionName::LT => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -500,7 +498,7 @@ where
                 .map(Some)
             }
             InstructionName::GT => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -510,7 +508,7 @@ where
                 .map(Some)
             }
             InstructionName::EQ => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -520,7 +518,7 @@ where
                 .map(Some)
             }
             InstructionName::ISZERO => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -530,7 +528,7 @@ where
                 .map(Some)
             }
             InstructionName::SLT => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -540,7 +538,7 @@ where
                 .map(Some)
             }
             InstructionName::SGT => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -551,7 +549,7 @@ where
             }
 
             InstructionName::OR => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::or(
                     context,
                     arguments[0].into_int_value(),
@@ -560,7 +558,7 @@ where
                 .map(Some)
             }
             InstructionName::XOR => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
@@ -569,7 +567,7 @@ where
                 .map(Some)
             }
             InstructionName::NOT => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
@@ -578,7 +576,7 @@ where
                 .map(Some)
             }
             InstructionName::AND => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::and(
                     context,
                     arguments[0].into_int_value(),
@@ -587,7 +585,7 @@ where
                 .map(Some)
             }
             InstructionName::SHL => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::shift_left(
                     context,
                     arguments[0].into_int_value(),
@@ -596,7 +594,7 @@ where
                 .map(Some)
             }
             InstructionName::SHR => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::shift_right(
                     context,
                     arguments[0].into_int_value(),
@@ -605,7 +603,7 @@ where
                 .map(Some)
             }
             InstructionName::SAR => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::shift_right_arithmetic(
                     context,
                     arguments[0].into_int_value(),
@@ -614,7 +612,7 @@ where
                 .map(Some)
             }
             InstructionName::BYTE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_bitwise::byte(
                     context,
                     arguments[0].into_int_value(),
@@ -624,7 +622,7 @@ where
             }
 
             InstructionName::ADDMOD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_math::add_mod(
                     context,
                     arguments[0].into_int_value(),
@@ -634,7 +632,7 @@ where
                 .map(Some)
             }
             InstructionName::MULMOD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_math::mul_mod(
                     context,
                     arguments[0].into_int_value(),
@@ -644,7 +642,7 @@ where
                 .map(Some)
             }
             InstructionName::EXP => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_math::exponent(
                     context,
                     arguments[0].into_int_value(),
@@ -653,7 +651,7 @@ where
                 .map(Some)
             }
             InstructionName::SIGNEXTEND => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_math::sign_extend(
                     context,
                     arguments[0].into_int_value(),
@@ -663,7 +661,7 @@ where
             }
 
             InstructionName::SHA3 | InstructionName::KECCAK256 => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_crypto::sha3(
                     context,
                     arguments[0].into_int_value(),
@@ -673,7 +671,7 @@ where
             }
 
             InstructionName::MLOAD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_memory::load(
                     context,
                     arguments[0].into_int_value(),
@@ -681,7 +679,7 @@ where
                 .map(Some)
             }
             InstructionName::MSTORE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_memory::store(
                     context,
                     arguments[0].into_int_value(),
@@ -690,7 +688,7 @@ where
                 .map(|_| None)
             }
             InstructionName::MSTORE8 => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_memory::store_byte(
                     context,
                     arguments[0].into_int_value(),
@@ -699,7 +697,7 @@ where
                 .map(|_| None)
             }
             InstructionName::MCOPY => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 let destination = revive_llvm_context::PolkaVMPointer::new_with_offset(
                     context,
                     revive_llvm_context::PolkaVMAddressSpace::Heap,
@@ -725,7 +723,7 @@ where
             }
 
             InstructionName::SLOAD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_storage::load(
                     context,
                     arguments[0].into_int_value(),
@@ -733,7 +731,7 @@ where
                 .map(Some)
             }
             InstructionName::SSTORE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_storage::store(
                     context,
                     arguments[0].into_int_value(),
@@ -742,7 +740,7 @@ where
                 .map(|_| None)
             }
             InstructionName::TLOAD => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_storage::transient_load(
                     context,
                     arguments[0].into_int_value(),
@@ -750,7 +748,7 @@ where
                 .map(Some)
             }
             InstructionName::TSTORE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_storage::transient_store(
                     context,
                     arguments[0].into_int_value(),
@@ -766,27 +764,28 @@ where
 
                 let offset = context
                     .solidity_mut()
-                    .get_or_allocate_immutable(key.as_str());
+                    .get_or_allocate_immutable(key.as_str())
+                    / revive_common::BYTE_LENGTH_WORD;
 
                 let index = context.word_const(offset as u64);
                 revive_llvm_context::polkavm_evm_immutable::load(context, index).map(Some)
             }
             InstructionName::ASSIGNIMMUTABLE => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
 
                 let key = self
                     .instruction
                     .value
                     .ok_or_else(|| anyhow::anyhow!("Instruction value missing"))?;
 
-                let offset = context.solidity_mut().allocate_immutable(key.as_str());
+                let offset = context.solidity_mut().allocate_immutable(key.as_str())
+                    / revive_common::BYTE_LENGTH_WORD;
 
                 let index = context.word_const(offset as u64);
                 let value = arguments.pop().expect("Always exists").into_int_value();
                 revive_llvm_context::polkavm_evm_immutable::store(context, index, value)
                     .map(|_| None)
             }
-
             InstructionName::CALLDATALOAD => {
                 match context
                     .code_type()
@@ -796,7 +795,7 @@ where
                         Ok(Some(context.word_const(0).as_basic_value_enum()))
                     }
                     revive_llvm_context::PolkaVMCodeType::Runtime => {
-                        let arguments = self.pop_arguments_llvm(context);
+                        let arguments = self.pop_arguments_llvm(context)?;
                         revive_llvm_context::polkavm_evm_calldata::load(
                             context,
                             arguments[0].into_int_value(),
@@ -819,7 +818,7 @@ where
                 }
             }
             InstructionName::CALLDATACOPY => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
 
                 match context
                     .code_type()
@@ -862,7 +861,7 @@ where
                 }
             }
             InstructionName::CODECOPY => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
 
                 let parent = context.module().get_name().to_str().expect("Always valid");
                 let source = &self.stack_input.elements[1];
@@ -917,7 +916,7 @@ where
                 revive_llvm_context::polkavm_evm_return_data::size(context).map(Some)
             }
             InstructionName::RETURNDATACOPY => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_return_data::copy(
                     context,
                     arguments[0].into_int_value(),
@@ -927,7 +926,7 @@ where
                 .map(|_| None)
             }
             InstructionName::EXTCODESIZE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_ext_code::size(
                     context,
                     Some(arguments[0].into_int_value()),
@@ -935,7 +934,7 @@ where
                 .map(Some)
             }
             InstructionName::EXTCODEHASH => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_ext_code::hash(
                     context,
                     arguments[0].into_int_value(),
@@ -944,7 +943,7 @@ where
             }
 
             InstructionName::RETURN => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_return::r#return(
                     context,
                     arguments[0].into_int_value(),
@@ -953,7 +952,7 @@ where
                 .map(|_| None)
             }
             InstructionName::REVERT => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_return::revert(
                     context,
                     arguments[0].into_int_value(),
@@ -969,7 +968,7 @@ where
             }
 
             InstructionName::LOG0 => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_event::log(
                     context,
                     arguments.remove(0).into_int_value(),
@@ -982,7 +981,7 @@ where
                 .map(|_| None)
             }
             InstructionName::LOG1 => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_event::log(
                     context,
                     arguments.remove(0).into_int_value(),
@@ -995,7 +994,7 @@ where
                 .map(|_| None)
             }
             InstructionName::LOG2 => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_event::log(
                     context,
                     arguments.remove(0).into_int_value(),
@@ -1008,7 +1007,7 @@ where
                 .map(|_| None)
             }
             InstructionName::LOG3 => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_event::log(
                     context,
                     arguments.remove(0).into_int_value(),
@@ -1021,7 +1020,7 @@ where
                 .map(|_| None)
             }
             InstructionName::LOG4 => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 revive_llvm_context::polkavm_evm_event::log(
                     context,
                     arguments.remove(0).into_int_value(),
@@ -1035,7 +1034,7 @@ where
             }
 
             InstructionName::CALL => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
 
                 let gas = arguments.remove(0).into_int_value();
                 let address = arguments.remove(0).into_int_value();
@@ -1060,7 +1059,7 @@ where
                 .map(Some)
             }
             InstructionName::STATICCALL => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
 
                 let gas = arguments.remove(0).into_int_value();
                 let address = arguments.remove(0).into_int_value();
@@ -1084,7 +1083,7 @@ where
                 .map(Some)
             }
             InstructionName::DELEGATECALL => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
 
                 let gas = arguments.remove(0).into_int_value();
                 let address = arguments.remove(0).into_int_value();
@@ -1108,7 +1107,7 @@ where
             }
 
             InstructionName::CREATE | InstructionName::ZK_CREATE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
 
                 let value = arguments[0].into_int_value();
                 let input_offset = arguments[1].into_int_value();
@@ -1124,7 +1123,7 @@ where
                 .map(Some)
             }
             InstructionName::CREATE2 | InstructionName::ZK_CREATE2 => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
 
                 let value = arguments[0].into_int_value();
                 let input_offset = arguments[1].into_int_value();
@@ -1155,7 +1154,7 @@ where
                 revive_llvm_context::polkavm_evm_ether_gas::gas(context).map(Some)
             }
             InstructionName::BALANCE => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
 
                 let address = arguments[0].into_int_value();
                 revive_llvm_context::polkavm_evm_ether_gas::balance(context, address).map(Some)
@@ -1184,7 +1183,7 @@ where
                 revive_llvm_context::polkavm_evm_contract_context::block_number(context).map(Some)
             }
             InstructionName::BLOCKHASH => {
-                let arguments = self.pop_arguments_llvm(context);
+                let arguments = self.pop_arguments_llvm(context)?;
                 let index = arguments[0].into_int_value();
 
                 revive_llvm_context::polkavm_evm_contract_context::block_hash(context, index)
@@ -1222,7 +1221,7 @@ where
                 anyhow::bail!("The `EXTCODECOPY` instruction is not supported");
             }
             InstructionName::SELFDESTRUCT => {
-                let _arguments = self.pop_arguments_llvm(context);
+                let _arguments = self.pop_arguments_llvm(context)?;
                 anyhow::bail!("The `SELFDESTRUCT` instruction is not supported");
             }
 
@@ -1234,7 +1233,7 @@ where
                 return_address,
                 ..
             } => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 arguments.pop();
                 arguments.reverse();
                 arguments.pop();
@@ -1297,7 +1296,7 @@ where
                 return Ok(());
             }
             InstructionName::RecursiveReturn { .. } => {
-                let mut arguments = self.pop_arguments_llvm(context);
+                let mut arguments = self.pop_arguments_llvm(context)?;
                 arguments.reverse();
                 arguments.pop();
 

--- a/crates/solidity/src/yul/parser/statement/expression/function_call/mod.rs
+++ b/crates/solidity/src/yul/parser/statement/expression/function_call/mod.rs
@@ -520,7 +520,7 @@ impl FunctionCall {
                 })?;
                 let offset = context.solidity_mut().allocate_immutable(key.as_str())
                     / revive_common::BYTE_LENGTH_WORD;
-                let index = context.word_const(offset as u64);
+                let index = context.xlen_type().const_int(offset as u64, false);
                 let value = arguments[2].value.into_int_value();
                 revive_llvm_context::polkavm_evm_immutable::store(context, index, value)
                     .map(|_| None)

--- a/crates/solidity/src/yul/parser/statement/object.rs
+++ b/crates/solidity/src/yul/parser/statement/object.rs
@@ -183,6 +183,7 @@ where
         &mut self,
         context: &mut revive_llvm_context::PolkaVMContext<D>,
     ) -> anyhow::Result<()> {
+        revive_llvm_context::PolkaVMImmutableDataLoadFunction.declare(context)?;
         let mut entry = revive_llvm_context::PolkaVMEntryFunction::default();
         entry.declare(context)?;
 
@@ -199,6 +200,7 @@ where
             revive_llvm_context::PolkaVMFunctionDeployCode,
             revive_llvm_context::PolkaVMFunctionRuntimeCode,
             revive_llvm_context::PolkaVMFunctionEntry,
+            revive_llvm_context::PolkaVMFunctionImmutableDataLoad,
         ]
         .into_iter()
         {
@@ -216,6 +218,7 @@ where
 
     fn into_llvm(self, context: &mut revive_llvm_context::PolkaVMContext<D>) -> anyhow::Result<()> {
         if self.identifier.ends_with("_deployed") {
+            revive_llvm_context::PolkaVMImmutableDataLoadFunction.into_llvm(context)?;
             revive_llvm_context::PolkaVMRuntimeCodeFunction::new(self.code).into_llvm(context)?;
         } else {
             revive_llvm_context::PolkaVMDeployCodeFunction::new(self.code).into_llvm(context)?;


### PR DESCRIPTION
This PR implements immutable variables in the codegen backend.

Notes on the implementation (this also differences from the ZKSync implementation):

- Do not explicitly store the index. The stored index is used to calculate the index itself. It follows that it can always be implied.
- We only store the final immutable data size (and the required memory buffer length) after we finished translating to LLVM IR. This way the observed immutable data size is not depended of the position of translated returns and immutable accesses.
- Do not return immutable data from the constructor; instead use the syscall.
- Lazily load the whole immutable data upon the first access. Once the data is loaded, just read from memory. This works by only syscalling into `get_immutable_data` if the immutable data size global variable is not 0 and writing back 0 into this global variable after the first (and only) call to `get_immutable_data`. 