### PR TITLE
[llvm-context,solidity] Add a command line option to output LLVM-IR

### DIFF
--- a/crates/llvm-context/src/polkavm/context/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/mod.rs
@@ -85,6 +85,10 @@ where
     dependency_manager: Option<D>,
     /// Whether to append the metadata hash at the end of bytecode.
     include_metadata_hash: bool,
+
+    /// Whether to emit LLVM-IR only.
+    output_llvm_ir: bool,
+
     /// The debug info of the current module.
     // debug_info: DebugInfo<'ctx>,
     /// The debug configuration telling whether to dump the needed IRs.
@@ -196,6 +200,7 @@ where
         optimizer: Optimizer,
         dependency_manager: Option<D>,
         include_metadata_hash: bool,
+        output_llvm_ir: bool,
         debug_config: Option<DebugConfig>,
     ) -> Self {
         Self::link_stdlib_module(llvm, &module);
@@ -221,7 +226,7 @@ where
 
             dependency_manager,
             include_metadata_hash,
-            // debug_info,
+            output_llvm_ir,
             debug_config,
 
             solidity_data: None,
@@ -274,37 +279,42 @@ where
             )
         })?;
 
-        let buffer = target_machine
-            .write_to_memory_buffer(self.module())
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "The contract `{}` assembly generating error: {}",
-                    contract_path,
-                    error
-                )
-            })?;
+        if self.output_llvm_ir {
+            let llvm_ir = self.module().print_to_string().to_string();
+            let build = Build::new(llvm_ir, None, vec![], String::new());
+            Ok(build)
+        } else {
+            let buffer = target_machine
+                .write_to_memory_buffer(self.module())
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "The contract `{}` assembly generating error: {}",
+                        contract_path,
+                        error
+                    )
+                })?;
 
-        let bytecode = revive_linker::link(buffer.as_slice())?;
+            let bytecode = revive_linker::link(buffer.as_slice())?;
 
-        let build = match crate::polkavm::build_assembly_text(
-            contract_path,
-            &bytecode,
-            metadata_hash,
-            self.debug_config(),
-        ) {
-            Ok(build) => build,
-            Err(_error)
-                if self.optimizer.settings() != &OptimizerSettings::size()
-                    && self.optimizer.settings().is_fallback_to_size_enabled() =>
-            {
-                self.optimizer = Optimizer::new(OptimizerSettings::size());
-                self.module = module_clone;
-                self.build(contract_path, metadata_hash)?
-            }
-            Err(error) => Err(error)?,
-        };
-
-        Ok(build)
+            let build = match crate::polkavm::build_assembly_text(
+                contract_path,
+                &bytecode,
+                metadata_hash,
+                self.debug_config(),
+            ) {
+                Ok(build) => build,
+                Err(_error)
+                    if self.optimizer.settings() != &OptimizerSettings::size()
+                        && self.optimizer.settings().is_fallback_to_size_enabled() =>
+                {
+                    self.optimizer = Optimizer::new(OptimizerSettings::size());
+                    self.module = module_clone;
+                    self.build(contract_path, metadata_hash)?
+                }
+                Err(error) => Err(error)?,
+            };
+            Ok(build)
+        }
     }
 
     /// Verifies the current LLVM IR module.
@@ -539,6 +549,7 @@ where
                         .map(|data| data.is_system_mode())
                         .unwrap_or_default(),
                     self.include_metadata_hash,
+                    false,
                     self.debug_config.clone(),
                 )
             })

--- a/crates/llvm-context/src/polkavm/context/tests.rs
+++ b/crates/llvm-context/src/polkavm/context/tests.rs
@@ -15,7 +15,7 @@ pub fn create_context(
     let module = llvm.create_module("test");
     let optimizer = Optimizer::new(optimizer_settings);
 
-    Context::<DummyDependency>::new(llvm, module, optimizer, None, true, None)
+    Context::<DummyDependency>::new(llvm, module, optimizer, None, true, false, None)
 }
 
 #[test]

--- a/crates/llvm-context/src/polkavm/mod.rs
+++ b/crates/llvm-context/src/polkavm/mod.rs
@@ -99,6 +99,7 @@ pub trait Dependency {
         optimizer_settings: OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        output_llvm_ir: bool,
         debug_config: Option<DebugConfig>,
     ) -> anyhow::Result<String>;
 
@@ -120,6 +121,7 @@ impl Dependency for DummyDependency {
         _optimizer_settings: OptimizerSettings,
         _is_system_mode: bool,
         _include_metadata_hash: bool,
+        _output_llvm_ir: bool,
         _debug_config: Option<DebugConfig>,
     ) -> anyhow::Result<String> {
         Ok(String::new())

--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -53,6 +53,7 @@ pub fn yul(
     optimizer_settings: revive_llvm_context::OptimizerSettings,
     is_system_mode: bool,
     include_metadata_hash: bool,
+    output_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
 ) -> anyhow::Result<Build> {
     let path = match input_files.len() {
@@ -83,6 +84,7 @@ pub fn yul(
         optimizer_settings,
         is_system_mode,
         include_metadata_hash,
+        output_llvm_ir,
         debug_config,
     )?;
 
@@ -112,6 +114,7 @@ pub fn llvm_ir(
         optimizer_settings,
         is_system_mode,
         include_metadata_hash,
+        false,
         debug_config,
     )?;
 
@@ -135,6 +138,7 @@ pub fn standard_output(
     allow_paths: Option<String>,
     remappings: Option<BTreeSet<String>>,
     suppressed_warnings: Option<Vec<Warning>>,
+    output_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
 ) -> anyhow::Result<Build> {
     let solc_version = solc.version()?;
@@ -202,6 +206,7 @@ pub fn standard_output(
         optimizer_settings,
         is_system_mode,
         include_metadata_hash,
+        output_llvm_ir,
         debug_config,
     )?;
 
@@ -218,6 +223,7 @@ pub fn standard_json(
     base_path: Option<String>,
     include_paths: Vec<String>,
     allow_paths: Option<String>,
+    output_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
 ) -> anyhow::Result<()> {
     let solc_version = solc.version()?;
@@ -279,6 +285,7 @@ pub fn standard_json(
             optimizer_settings,
             is_system_mode,
             include_metadata_hash,
+            output_llvm_ir,
             debug_config,
         )?;
         build.write_to_standard_json(&mut solc_output, &solc_version, &resolc_version)?;
@@ -305,6 +312,7 @@ pub fn combined_json(
     allow_paths: Option<String>,
     remappings: Option<BTreeSet<String>>,
     suppressed_warnings: Option<Vec<Warning>>,
+    output_llvm_ir: bool,
     debug_config: Option<revive_llvm_context::DebugConfig>,
     output_directory: Option<PathBuf>,
     overwrite: bool,
@@ -326,6 +334,7 @@ pub fn combined_json(
         allow_paths,
         remappings,
         suppressed_warnings,
+        output_llvm_ir,
         debug_config,
     )?;
 

--- a/crates/solidity/src/process/input.rs
+++ b/crates/solidity/src/process/input.rs
@@ -20,6 +20,8 @@ pub struct Input {
     pub include_metadata_hash: bool,
     /// The optimizer settings.
     pub optimizer_settings: revive_llvm_context::OptimizerSettings,
+    /// Whether to output LLVM-IR.
+    pub output_llvm_ir: bool,
     /// The debug output config.
     pub debug_config: Option<revive_llvm_context::DebugConfig>,
 }
@@ -32,6 +34,7 @@ impl Input {
         is_system_mode: bool,
         include_metadata_hash: bool,
         optimizer_settings: revive_llvm_context::OptimizerSettings,
+        output_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> Self {
         Self {
@@ -40,6 +43,7 @@ impl Input {
             is_system_mode,
             include_metadata_hash,
             optimizer_settings,
+            output_llvm_ir,
             debug_config,
         }
     }

--- a/crates/solidity/src/process/mod.rs
+++ b/crates/solidity/src/process/mod.rs
@@ -45,6 +45,7 @@ pub fn run(input_file: Option<&mut std::fs::File>) -> anyhow::Result<()> {
         input.optimizer_settings,
         input.is_system_mode,
         input.include_metadata_hash,
+        input.output_llvm_ir,
         input.debug_config,
     );
 

--- a/crates/solidity/src/project/contract/mod.rs
+++ b/crates/solidity/src/project/contract/mod.rs
@@ -80,6 +80,7 @@ impl Contract {
         optimizer_settings: revive_llvm_context::OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        output_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         let llvm = inkwell::context::Context::create();
@@ -122,6 +123,7 @@ impl Contract {
             optimizer,
             Some(project),
             include_metadata_hash,
+            output_llvm_ir,
             debug_config,
         );
         context.set_solidity_data(revive_llvm_context::PolkaVMContextSolidityData::default());

--- a/crates/solidity/src/project/mod.rs
+++ b/crates/solidity/src/project/mod.rs
@@ -64,6 +64,7 @@ impl Project {
         optimizer_settings: revive_llvm_context::OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        output_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<Build> {
         let project = self.clone();
@@ -77,6 +78,7 @@ impl Project {
                     is_system_mode,
                     include_metadata_hash,
                     optimizer_settings.clone(),
+                    output_llvm_ir,
                     debug_config.clone(),
                 ));
 
@@ -241,6 +243,7 @@ impl revive_llvm_context::PolkaVMDependency for Project {
         optimizer_settings: revive_llvm_context::OptimizerSettings,
         is_system_mode: bool,
         include_metadata_hash: bool,
+        output_llvm_ir: bool,
         debug_config: Option<revive_llvm_context::DebugConfig>,
     ) -> anyhow::Result<String> {
         let contract_path = project.resolve_path(identifier)?;
@@ -261,6 +264,7 @@ impl revive_llvm_context::PolkaVMDependency for Project {
                 optimizer_settings,
                 is_system_mode,
                 include_metadata_hash,
+                output_llvm_ir,
                 debug_config,
             )
             .map_err(|error| {

--- a/crates/solidity/src/resolc/arguments.rs
+++ b/crates/solidity/src/resolc/arguments.rs
@@ -174,6 +174,12 @@ pub struct Arguments {
     #[cfg(debug_assertions)]
     #[structopt(long = "recursive-process-input")]
     pub recursive_process_input: Option<String>,
+
+    /// Output LLVM-IR of the contracts.
+    /// This is only intended for use when developing the compiler.
+    #[cfg(debug_assertions)]
+    #[structopt(long = "output-llvm-ir")]
+    pub output_llvm_ir: bool,
 }
 
 impl Default for Arguments {
@@ -211,6 +217,13 @@ impl Arguments {
         #[cfg(not(debug_assertions))]
         if self.recursive_process && std::env::args().count() > 2 {
             anyhow::bail!("No other options are allowed in recursive mode.");
+        }
+
+        #[cfg(debug_assertions)]
+        if self.output_llvm_ir {
+            if self.output_assembly || self.output_binary {
+                anyhow::bail!("Can't output LLVM-IR as well as PolkaVM assembly or bytecode.");
+            }
         }
 
         let modes_count = [

--- a/crates/solidity/src/test_utils.rs
+++ b/crates/solidity/src/test_utils.rs
@@ -106,7 +106,7 @@ pub fn build_solidity_with_options(
 
     let project = output.try_to_project(sources, libraries, pipeline, &solc_version, None)?;
 
-    let build: crate::Build = project.compile(optimizer_settings, false, false, None)?;
+    let build: crate::Build = project.compile(optimizer_settings, false, false, false, None)?;
     build.write_to_standard_json(
         &mut output,
         &solc_version,
@@ -229,7 +229,7 @@ pub fn build_yul(source_code: &str) -> anyhow::Result<()> {
 
     let project =
         Project::try_from_yul_string(PathBuf::from("test.yul").as_path(), source_code, None)?;
-    let _build = project.compile(optimizer_settings, false, false, None)?;
+    let _build = project.compile(optimizer_settings, false, false, false, None)?;
 
     Ok(())
 }


### PR DESCRIPTION
Add option '--output-llvm-ir' to output LLVM-IR for each contract. This is only available in debug builds. It cannot be used with '--asm' or '--bin'.