### PR TITLE
deny clippy warnings by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ bench: install-bin
 	| criterion-table > crates/benchmarks/BENCHMARKS.md
 
 clippy:
-	cargo clippy --all-features --workspace --tests --benches
+	cargo clippy --all-features --workspace --tests --benches -- --deny warnings --allow dead_code
 
 docs: docs-build
 	mdbook serve --open docs/


### PR DESCRIPTION
`--allow dead_code` will resolve after #66