### PR TITLE
improve runtime api return value names

### DIFF
--- a/crates/llvm-context/src/polkavm/context/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/mod.rs
@@ -907,7 +907,7 @@ where
                     .copied()
                     .map(inkwell::values::BasicMetadataValueEnum::from)
                     .collect::<Vec<_>>(),
-                &format!("runtime API call {name}"),
+                &format!("runtime_api_{name}"),
             )
             .unwrap()
             .try_as_basic_value()

--- a/crates/llvm-context/src/polkavm/context/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/mod.rs
@@ -907,7 +907,7 @@ where
                     .copied()
                     .map(inkwell::values::BasicMetadataValueEnum::from)
                     .collect::<Vec<_>>(),
-                &format!("runtime_api_{name}"),
+                &format!("runtime_api_{name}_return_value"),
             )
             .unwrap()
             .try_as_basic_value()


### PR DESCRIPTION
Some change to runtime api call method to make it easy to read `ll` generated code.

before
```ll
%"runtime API call call" = call i32 @call(i32 %call_argument_pointer)
%is_success.not = icmp eq i32 %"runtime API call call", 0
```
after
```ll
%runtime_api_call_return_value = call i32 @call(i32 %call_argument_pointer)
%is_success = icmp eq i32 %runtime_api_call_return_value, 0
```