### PR TITLE
revive-runner: consider only non-reverted transactions as success

### DIFF
--- a/crates/differential/src/lib.rs
+++ b/crates/differential/src/lib.rs
@@ -40,7 +40,7 @@ const EXECUTABLE_ARGS_BENCH: [&str; 6] = [
     "-",
 ];
 const GAS_USED_MARKER: &str = "EVM gas used:";
-const REVERT_MARKER: &str = "error: execution reverted";
+const REVERT_MARKER: &str = " error: ";
 
 /// The geth EVM state dump structure
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/crates/integration/contracts/Call.sol
+++ b/crates/integration/contracts/Call.sol
@@ -21,16 +21,8 @@ pragma solidity ^0.8;
                     "Solidity": {
                         "contract": "Caller"
                     }
-                }
-            }
-        },
-        {
-            "Call": {
-                "dest": {
-                    "Instantiated": 0
                 },
-                "value": 123,
-                "data": "1eb16e5b000000000000000000000000d8b934580fce35a11b58c6d73adee468a2833fa8"
+                "value": 123
             }
         },
         {
@@ -49,11 +41,14 @@ contract Callee {
     function echo(bytes memory payload) public pure returns (bytes memory) {
         return payload;
     }
+
+    receive() external payable {}
 }
 
 contract Caller {
-    function value_transfer(address payable destination) public payable {
-        destination.transfer(msg.value);
+    constructor() payable {
+        Callee callee = new Callee();
+        payable(address(callee)).transfer(msg.value);
     }
 
     function call(bytes memory payload) public returns (bytes memory) {


### PR DESCRIPTION
The pallet returns the `Ok` variant when the transaction did revert, so we should also consider the revert flag.