### PR TITLE
update polkadot-sdk and inkwell dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,18 +105,18 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
 dependencies = [
- "alloy-primitives 0.8.9",
+ "alloy-primitives 0.8.10",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5671117c38b1c2306891f97ad3828d85487087f54ebe2c7591a055ea5bcea7"
+checksum = "31a0f0d51db8a1a30a4d98a9f90e090a94c8f44cb4d9eafc7e03aa6d00aae984"
 dependencies = [
- "alloy-primitives 0.8.9",
+ "alloy-primitives 0.8.10",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71738eb20c42c5fb149571e76536a0f309d142f3957c28791662b96baf77a3d"
+checksum = "8edae627382349b56cd6a7a2106f4fd69b243a9233e560c55c2e03cabb7e1d3c"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -186,7 +186,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
- "alloy-primitives 0.8.9",
+ "alloy-primitives 0.8.10",
  "serde",
  "serde_json",
 ]
@@ -203,30 +203,30 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "syn-solidity 0.4.2",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0900b83f4ee1f45c640ceee596afbc118051921b9438fdb5a3175c1a7e05f8b"
+checksum = "841eabaa4710f719fddbc24c95d386eae313f07e6da4babc25830ee37945be0c"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41b1e78dde06b5e12e6702fa8c1d30621bf07728ba75b801fb801c9c6a0ba10"
+checksum = "6672337f19d837b9f7073c45853aeb528ed9f7dd6a4154ce683e9e5cb7794014"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -235,31 +235,31 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
- "syn-solidity 0.8.9",
+ "syn 2.0.85",
+ "syn-solidity 0.8.10",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91dc311a561a306664393407b88d3e53ae58581624128afd8a15faa5de3627dc"
+checksum = "0dff37dd20bfb118b777c96eda83b2067f4226d2644c5cfa00187b3bc01770ba"
 dependencies = [
  "const-hex",
  "dunce",
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
- "syn-solidity 0.8.9",
+ "syn 2.0.85",
+ "syn-solidity 0.8.10",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d1fbee9e698f3ba176b6e7a145f4aefe6d2b746b611e8bb246fe11a0e9f6c4"
+checksum = "5b853d42292dbb159671a3edae3b2750277ff130f32b726fe07dc2b17aa6f2b5"
 dependencies = [
  "serde",
  "winnow",
@@ -279,13 +279,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086f41bc6ebcd8cb15f38ba20e47be38dd03692149681ce8061c35d960dbf850"
+checksum = "aa828bb1b9a6dc52208fbb18084fb9ce2c30facc2bfda6a5d922349b4990354f"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.9",
- "alloy-sol-macro 0.8.9",
+ "alloy-primitives 0.8.10",
+ "alloy-sol-macro 0.8.10",
  "const-hex",
  "serde",
 ]
@@ -298,9 +298,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -313,43 +313,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "approx"
@@ -371,7 +371,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -805,7 +805,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "hash-db",
  "log",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1082,13 +1082,13 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1098,13 +1098,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1115,26 +1115,26 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "bp-polkadot"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1145,13 +1145,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1163,13 +1163,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1184,7 +1184,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "trie-db",
 ]
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1205,14 +1205,14 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1222,14 +1222,14 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1241,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1251,14 +1251,14 @@ dependencies = [
  "snowbridge-core",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1292,7 +1292,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1323,7 +1323,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "sp-weights",
  "staging-xcm",
@@ -1520,7 +1520,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1964,12 +1964,12 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "sp-version",
  "staging-xcm",
@@ -1980,18 +1980,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2083,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2113,17 +2113,17 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2201,7 +2201,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2228,7 +2228,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2245,7 +2245,7 @@ checksum = "a1719100f31492cd6adeeab9a0f46cdbc846e615fdb66d7b398aa46ec7fdd06f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2293,7 +2293,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2315,7 +2315,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2356,7 +2356,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2367,7 +2367,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2380,7 +2380,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2400,7 +2400,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "unicode-xid",
 ]
 
@@ -2483,7 +2483,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.82",
+ "syn 2.0.85",
  "termcolor",
  "toml 0.8.19",
  "walkdir",
@@ -2631,7 +2631,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2642,7 +2642,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2756,7 +2756,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2917,15 +2917,15 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2939,18 +2939,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2978,7 +2978,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3047,7 +3047,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -3055,8 +3055,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "sp-weights",
  "static_assertions",
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3079,36 +3079,36 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "syn 2.0.82",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3120,7 +3120,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-version",
  "sp-weights",
 ]
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3142,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3232,7 +3232,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3675,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3834,8 +3834,7 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 [[package]]
 name = "inkwell"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fb405537710d51f6bdbc8471365ddd4cd6d3a3c3ad6e0c8291691031ba94b2"
+source = "git+https://github.com/TheDan64/inkwell.git?rev=7b410298b6a93450adaa90b1841d5805a3038f12#7b410298b6a93450adaa90b1841d5805a3038f12"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -3849,12 +3848,11 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd28cfd4cfba665d47d31c08a6ba637eed16770abca2eccbbc3ca831fef1e44"
+source = "git+https://github.com/TheDan64/inkwell.git?rev=7b410298b6a93450adaa90b1841d5805a3038f12#7b410298b6a93450adaa90b1841d5805a3038f12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4079,7 +4077,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4202,9 +4200,9 @@ checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -4315,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "llvm-sys"
-version = "180.0.0"
+version = "181.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778fa5fa02e32728e718f11eec147e6f134137399ab02fd2c13d32476337affa"
+checksum = "d320f9d2723c97d4b78f9190a61ed25cc7cfbe456668c08e6e7dd8e50ceb8500"
 dependencies = [
  "anyhow",
  "cc",
@@ -4361,7 +4359,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4375,7 +4373,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4386,7 +4384,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4397,7 +4395,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4437,7 +4435,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -4508,9 +4506,9 @@ checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
 
 [[package]]
 name = "nalgebra"
-version = "0.33.1"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf139e93ad757869338ad85239cb1d6c067b23b94e5846e637ca6328ee4be60"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -4584,7 +4582,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4711,7 +4709,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-alliance"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4722,7 +4720,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-io",
  "sp-runtime",
 ]
@@ -4730,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4748,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4766,7 +4764,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4781,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4795,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4812,7 +4810,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4828,7 +4826,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4843,7 +4841,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4857,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4873,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4888,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4901,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4924,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "aquamarine",
  "docify",
@@ -4939,13 +4937,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -4960,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4979,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5004,7 +5002,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5021,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5034,13 +5032,13 @@ dependencies = [
  "scale-info",
  "sp-consensus-grandpa",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -5052,14 +5050,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -5073,13 +5071,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -5097,13 +5095,13 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -5121,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5139,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5158,7 +5156,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5175,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5189,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -5211,7 +5209,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -5221,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5246,7 +5244,7 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -5256,17 +5254,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -5277,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5293,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5311,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5326,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5343,7 +5341,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5358,7 +5356,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5380,7 +5378,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5393,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5411,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5429,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "blake2",
  "frame-benchmarking",
@@ -5447,7 +5445,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5469,7 +5467,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5485,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5504,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5520,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5533,7 +5531,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5546,7 +5544,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5562,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -5581,7 +5579,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5599,7 +5597,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5618,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5635,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5650,7 +5648,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5666,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5683,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
@@ -5693,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5708,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5723,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5735,13 +5733,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5754,14 +5752,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -5771,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5787,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5810,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5827,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5844,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5860,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5874,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5892,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5906,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5923,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5939,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitflags 1.3.2",
  "derive_more 0.99.18",
@@ -5969,7 +5967,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-builder",
@@ -5979,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "anyhow",
  "frame-system",
@@ -5996,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-mock-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6020,7 +6018,7 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -6030,17 +6028,17 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -6052,7 +6050,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6067,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6081,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6099,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6117,7 +6115,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6134,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6147,7 +6145,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6168,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6184,7 +6182,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6196,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6213,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6234,7 +6232,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6243,7 +6241,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6253,7 +6251,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6269,7 +6267,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6286,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6301,7 +6299,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6313,14 +6311,14 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6338,7 +6336,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6354,7 +6352,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6366,7 +6364,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6385,7 +6383,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6404,7 +6402,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6421,7 +6419,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6435,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6450,7 +6448,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6466,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6480,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6494,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -6517,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6535,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -6548,7 +6546,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -6557,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -6568,7 +6566,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -6576,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -6606,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -6626,7 +6624,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -6760,29 +6758,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -6847,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6858,7 +6856,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.18",
@@ -6874,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -6895,13 +6893,13 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -6951,19 +6949,19 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bs58",
  "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -7003,7 +7001,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -7011,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -7203,11 +7201,11 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-core-hashing",
- "sp-crypto-ec-utils 0.10.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-ec-utils 0.10.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -7219,22 +7217,22 @@ dependencies = [
  "sp-npos-elections",
  "sp-offchain",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-session",
  "sp-staking",
  "sp-state-machine",
  "sp-statement-store",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-timestamp",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
  "sp-version",
  "sp-version-proc-macro",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-weights",
  "staging-parachain-info",
  "staging-xcm",
@@ -7248,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7267,12 +7265,14 @@ dependencies = [
  "sp-consensus-aura",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
+ "sp-keyring",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-transaction-pool",
  "sp-version",
 ]
@@ -7368,7 +7368,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7380,7 +7380,7 @@ dependencies = [
  "polkavm-common 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7390,7 +7390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7400,7 +7400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f3ad876ca1855038c21d48cbe35164552208a54b21f8295a7d76bc33ef1e38"
 dependencies = [
  "polkavm-derive-impl 0.13.0",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7487,12 +7487,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7575,7 +7575,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7751,7 +7751,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7781,9 +7781,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7833,7 +7833,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "revive-benchmarks"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.9",
+ "alloy-primitives 0.8.10",
  "criterion",
  "hex",
  "revive-differential",
@@ -7860,7 +7860,7 @@ name = "revive-differential"
 version = "0.1.0"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.9",
+ "alloy-primitives 0.8.10",
  "alloy-serde",
  "hex",
  "serde",
@@ -7872,8 +7872,8 @@ dependencies = [
 name = "revive-integration"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.9",
- "alloy-sol-types 0.8.9",
+ "alloy-primitives 0.8.10",
+ "alloy-sol-types 0.8.10",
  "env_logger",
  "hex",
  "log",
@@ -7932,7 +7932,7 @@ dependencies = [
 name = "revive-runner"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.9",
+ "alloy-primitives 0.8.10",
  "hex",
  "parity-scale-codec",
  "polkadot-sdk",
@@ -8060,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8176,9 +8176,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -8189,9 +8189,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.15"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "log",
  "once_cell",
@@ -8322,18 +8322,18 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -8343,25 +8343,25 @@ dependencies = [
  "schnellru",
  "sp-api",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "thiserror",
  "wasm-instrument",
 ]
@@ -8369,18 +8369,18 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "log",
  "polkavm 0.9.3",
  "sc-executor-common",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8390,8 +8390,8 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "wasmtime",
 ]
 
@@ -8459,14 +8459,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "scale-info"
-version = "2.11.4"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22760a375f81a31817aeaf6f5081e9ccb7ffd7f2da1809a6e3fc82b6656f10d5"
+checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -8478,14 +8478,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.4"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc61ebe25a5c410c0e245028fc9934bf8fa4817199ef5a24a68092edfd34614"
+checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8691,9 +8691,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.212"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd4055b7e3937a5c2595e974f5bf1715a23919a595a04b5ad959bdbbb61ab04"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
@@ -8718,13 +8718,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.212"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726adf8349784fb68a42e6466f49362ae039d9c5333cc6eb131f4d6f94bb9126"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8885,7 +8885,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -8912,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -8926,7 +8926,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "ssz_rs",
  "ssz_rs_derive",
 ]
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -8949,7 +8949,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "ethabi-decode",
  "ethbloom 0.14.1",
@@ -8971,7 +8971,7 @@ dependencies = [
  "serde-big-array",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
@@ -8992,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9003,20 +9003,20 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "snowbridge-core",
  "snowbridge-outbound-queue-merkle-tree",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9033,26 +9033,26 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "static_assertions",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "alloy-primitives 0.4.2",
  "alloy-sol-types 0.4.2",
@@ -9071,7 +9071,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -9079,19 +9079,19 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -9107,13 +9107,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9125,7 +9125,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-router-primitives"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -9144,7 +9144,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-executor",
 ]
@@ -9152,14 +9152,14 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-common"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "log",
  "parity-scale-codec",
  "snowbridge-core",
  "sp-arithmetic",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-test-common"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -9199,12 +9199,12 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
 ]
 
@@ -9237,7 +9237,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "hash-db",
@@ -9246,10 +9246,10 @@ dependencies = [
  "scale-info",
  "sp-api-proc-macro",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-state-machine",
  "sp-trie",
  "sp-version",
@@ -9259,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "Inflector",
  "blake2",
@@ -9267,13 +9267,13 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9285,7 +9285,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -9317,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9339,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9373,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9381,7 +9381,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -9393,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9410,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9421,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9432,7 +9432,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "array-bytes",
  "bandersnatch_vrfs",
@@ -9462,12 +9462,12 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -9479,15 +9479,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -9501,13 +9501,13 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -9541,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9554,47 +9554,47 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "syn 2.0.82",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9604,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bytes",
  "docify",
@@ -9641,12 +9641,12 @@ dependencies = [
  "rustversion",
  "secp256k1",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-keystore",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-state-machine",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9665,18 +9665,18 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9685,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9715,7 +9715,7 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-core",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-runtime",
  "thiserror",
 ]
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9746,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "backtrace",
  "regex",
@@ -9755,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -9774,7 +9774,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-trie",
  "sp-weights",
  "tracing",
@@ -9784,26 +9784,26 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive 0.9.1",
  "primitive-types 0.13.1",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9822,33 +9822,33 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9862,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9875,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "hash-db",
  "log",
@@ -9884,7 +9884,7 @@ dependencies = [
  "rand",
  "smallvec",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-panic-handler",
  "sp-trie",
  "thiserror",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -9908,10 +9908,10 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "thiserror",
  "x25519-dalek",
 ]
@@ -9919,29 +9919,29 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9965,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9976,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "ahash",
  "hash-db",
@@ -10022,7 +10022,7 @@ dependencies = [
  "scale-info",
  "schnellru",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "thiserror",
  "tracing",
  "trie-db",
@@ -10032,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -10041,7 +10041,7 @@ dependencies = [
  "serde",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -10049,19 +10049,19 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10073,7 +10073,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10092,7 +10092,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
 ]
 
 [[package]]
@@ -10171,7 +10171,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10184,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -10203,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10309,13 +10309,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -10327,7 +10327,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -10428,9 +10428,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10446,19 +10446,19 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5e0c2ea8db64b2898b62ea2fbd60204ca95e0b2c6bdf53ff768bbe916fbe4d"
+checksum = "16320d4a2021ba1a32470b3759676114a918885e9800e68ad60f2c67969fba62"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -10482,7 +10482,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.59.0",
 ]
 
@@ -10498,7 +10498,7 @@ dependencies = [
 [[package]]
 name = "testnet-parachains-constants"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10512,22 +10512,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -10629,7 +10629,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -10759,7 +10759,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11053,7 +11053,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -11087,7 +11087,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11445,7 +11445,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -11737,18 +11737,18 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -11762,7 +11762,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93#aeebf2f383390f2f86527d70212162d5dbea8b93"
+source = "git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1#35535efb3d9f4d3b3be63c3c2bcf963883ab6af1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11775,7 +11775,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=aeebf2f383390f2f86527d70212162d5dbea8b93)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=35535efb3d9f4d3b3be63c3c2bcf963883ab6af1)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11799,7 +11799,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -11819,7 +11819,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,12 @@ log = { version = "0.4" }
 # polkadot-sdk and friends
 codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }
 scale-info = { version = "2.11.1", default-features = false }
-polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", rev = "aeebf2f383390f2f86527d70212162d5dbea8b93" }
+polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", rev = "35535efb3d9f4d3b3be63c3c2bcf963883ab6af1" }
 
 # llvm
 [workspace.dependencies.inkwell]
-version = "0.5"
+git = "https://github.com/TheDan64/inkwell.git"
+rev = "7b410298b6a93450adaa90b1841d5805a3038f12"
 default-features = false
 features = ["serde", "llvm18-0", "no-libffi-linking", "target-riscv"]
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -72,7 +72,7 @@ impl ExtBuilder {
         Self {
             balance_genesis_config: value
                 .iter()
-                .map(|(address, balance)| (AccountId::to_account_id(address), *balance))
+                .map(|(address, balance)| (AccountId::to_fallback_account_id(address), *balance))
                 .collect(),
         }
     }

--- a/crates/runner/src/runtime.rs
+++ b/crates/runner/src/runtime.rs
@@ -1,5 +1,6 @@
 use frame_support::runtime;
 
+use pallet_revive::AccountId32Mapper;
 use polkadot_sdk::*;
 use polkadot_sdk::{
     polkadot_sdk_frame::{log, runtime::prelude::*},
@@ -7,7 +8,7 @@ use polkadot_sdk::{
 };
 
 pub type Balance = u128;
-pub type AccountId = pallet_revive::DefaultAddressMapper;
+pub type AccountId = pallet_revive::AccountId32Mapper<Runtime>;
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
 pub type Hash = <Runtime as frame_system::Config>::Hash;
 pub type EventRecord =
@@ -74,7 +75,7 @@ impl pallet_revive::Config for Runtime {
     type ChainExtension = ();
     type DepositPerByte = DepositPerByte;
     type DepositPerItem = DepositPerItem;
-    type AddressMapper = AccountId;
+    type AddressMapper = AccountId32Mapper<Self>;
     type RuntimeMemory = ConstU32<{ 512 * 1024 * 1024 }>;
     type PVFMemory = ConstU32<{ 1024 * 1024 * 1024 }>;
     type UnsafeUnstableInterface = UnstableInterface;

--- a/crates/runner/src/specs.rs
+++ b/crates/runner/src/specs.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 
-use pallet_revive::AddressMapper;
 use serde::{Deserialize, Serialize};
 
 use crate::*;


### PR DESCRIPTION
- Switch to an unreleased inkwell version which fixes a musl cross compilation bug
- Update the polkadot-sdk dependency