### PR TITLE
display the git revision version information

### DIFF
--- a/crates/solidity/build.rs
+++ b/crates/solidity/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let git_rev = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .map(|out| String::from_utf8(out.stdout).unwrap_or_default())
+        .unwrap_or("unknown".to_owned());
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_rev.trim());
+}

--- a/crates/solidity/src/resolc/main.rs
+++ b/crates/solidity/src/resolc/main.rs
@@ -31,10 +31,11 @@ fn main_inner() -> anyhow::Result<()> {
 
     if arguments.version {
         println!(
-            "{} v{} (LLVM build {:?})",
+            "{} v{} rev-{} (LLVM build {:?})",
             env!("CARGO_PKG_DESCRIPTION"),
             env!("CARGO_PKG_VERSION"),
-            inkwell::support::get_llvm_version()
+            env!("GIT_COMMIT_HASH"),
+            inkwell::support::get_llvm_version(),
         );
         return Ok(());
     }


### PR DESCRIPTION
Looks like this:

```
❯ resolc --version
Solidity frontend for the revive compiler v0.1.0 rev-36d9317 (LLVM build (18, 1, 8))
```