### PR TITLE
solidity: rename the revive metadata

### DIFF
--- a/crates/solidity/src/build/mod.rs
+++ b/crates/solidity/src/build/mod.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use crate::solc::combined_json::CombinedJson;
 use crate::solc::standard_json::output::Output as StandardJsonOutput;
 use crate::solc::version::Version as SolcVersion;
+use crate::ResolcVersion;
 
 use self::contract::Contract;
 
@@ -40,11 +41,7 @@ impl Build {
     }
 
     /// Writes all contracts assembly and bytecode to the combined JSON.
-    pub fn write_to_combined_json(
-        self,
-        combined_json: &mut CombinedJson,
-        resolc_version: &semver::Version,
-    ) -> anyhow::Result<()> {
+    pub fn write_to_combined_json(self, combined_json: &mut CombinedJson) -> anyhow::Result<()> {
         for (path, contract) in self.contracts.into_iter() {
             let combined_json_contract = combined_json
                 .contracts
@@ -61,7 +58,7 @@ impl Build {
             contract.write_to_combined_json(combined_json_contract)?;
         }
 
-        combined_json.zk_version = Some(resolc_version.to_string());
+        combined_json.revive_version = Some(ResolcVersion::default().long);
 
         Ok(())
     }
@@ -90,7 +87,11 @@ impl Build {
 
         standard_json.version = Some(solc_version.default.to_string());
         standard_json.long_version = Some(solc_version.long.to_owned());
-        standard_json.zk_version = Some(resolc_version.to_string());
+        standard_json.revive_version = Some(format!(
+            "{}+commit.{}",
+            resolc_version,
+            env!("GIT_COMMIT_HASH")
+        ));
 
         Ok(())
     }

--- a/crates/solidity/src/build/mod.rs
+++ b/crates/solidity/src/build/mod.rs
@@ -68,7 +68,6 @@ impl Build {
         mut self,
         standard_json: &mut StandardJsonOutput,
         solc_version: &SolcVersion,
-        resolc_version: &semver::Version,
     ) -> anyhow::Result<()> {
         let contracts = match standard_json.contracts.as_mut() {
             Some(contracts) => contracts,
@@ -87,11 +86,7 @@ impl Build {
 
         standard_json.version = Some(solc_version.default.to_string());
         standard_json.long_version = Some(solc_version.long.to_owned());
-        standard_json.revive_version = Some(format!(
-            "{}+commit.{}",
-            resolc_version,
-            env!("GIT_COMMIT_HASH")
-        ));
+        standard_json.revive_version = Some(ResolcVersion::default().long);
 
         Ok(())
     }

--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -199,7 +199,6 @@ pub fn standard_json(
 ) -> anyhow::Result<()> {
     let solc_version = solc.version()?;
     let solc_pipeline = SolcPipeline::new(&solc_version, force_evmla);
-    let resolc_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
 
     let solc_input = SolcStandardJsonInput::try_from_stdin(solc_pipeline)?;
     let source_code_files = solc_input
@@ -249,7 +248,7 @@ pub fn standard_json(
         missing_libraries.write_to_standard_json(&mut solc_output, &solc_version)?;
     } else {
         let build = project.compile(optimizer_settings, include_metadata_hash, debug_config)?;
-        build.write_to_standard_json(&mut solc_output, &solc_version, &resolc_version)?;
+        build.write_to_standard_json(&mut solc_output, &solc_version)?;
     }
     serde_json::to_writer(std::io::stdout(), &solc_output)?;
     std::process::exit(0);

--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -7,6 +7,7 @@ pub(crate) mod missing_libraries;
 pub(crate) mod process;
 pub(crate) mod project;
 pub(crate) mod solc;
+pub(crate) mod version;
 pub(crate) mod warning;
 pub(crate) mod yul;
 
@@ -38,6 +39,7 @@ pub use self::solc::standard_json::output::contract::Contract as SolcStandardJso
 pub use self::solc::standard_json::output::Output as SolcStandardJsonOutput;
 pub use self::solc::version::Version as SolcVersion;
 pub use self::solc::Compiler as SolcCompiler;
+pub use self::version::Version as ResolcVersion;
 pub use self::warning::Warning;
 
 pub mod test_utils;
@@ -244,11 +246,7 @@ pub fn standard_json(
 
     if detect_missing_libraries {
         let missing_libraries = project.get_missing_libraries();
-        missing_libraries.write_to_standard_json(
-            &mut solc_output,
-            &solc_version,
-            &resolc_version,
-        )?;
+        missing_libraries.write_to_standard_json(&mut solc_output, &solc_version)?;
     } else {
         let build = project.compile(optimizer_settings, include_metadata_hash, debug_config)?;
         build.write_to_standard_json(&mut solc_output, &solc_version, &resolc_version)?;
@@ -278,8 +276,6 @@ pub fn combined_json(
     output_directory: Option<PathBuf>,
     overwrite: bool,
 ) -> anyhow::Result<()> {
-    let resolc_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
-
     let build = standard_output(
         input_files,
         libraries,
@@ -298,7 +294,7 @@ pub fn combined_json(
     )?;
 
     let mut combined_json = solc.combined_json(input_files, format.as_str())?;
-    build.write_to_combined_json(&mut combined_json, &resolc_version)?;
+    build.write_to_combined_json(&mut combined_json)?;
 
     match output_directory {
         Some(output_directory) => {

--- a/crates/solidity/src/missing_libraries.rs
+++ b/crates/solidity/src/missing_libraries.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 use crate::solc::standard_json::output::Output as StandardJsonOutput;
 use crate::solc::version::Version as SolcVersion;
+use crate::ResolcVersion;
 
 /// The missing Solidity libraries.
 pub struct MissingLibraries {
@@ -23,7 +24,6 @@ impl MissingLibraries {
         mut self,
         standard_json: &mut StandardJsonOutput,
         solc_version: &SolcVersion,
-        resolc_version: &semver::Version,
     ) -> anyhow::Result<()> {
         let contracts = match standard_json.contracts.as_mut() {
             Some(contracts) => contracts,
@@ -43,7 +43,7 @@ impl MissingLibraries {
 
         standard_json.version = Some(solc_version.default.to_string());
         standard_json.long_version = Some(solc_version.long.to_owned());
-        standard_json.zk_version = Some(resolc_version.to_string());
+        standard_json.revive_version = Some(ResolcVersion::default().long);
 
         Ok(())
     }

--- a/crates/solidity/src/project/contract/metadata.rs
+++ b/crates/solidity/src/project/contract/metadata.rs
@@ -10,10 +10,10 @@ pub struct Metadata {
     pub solc_metadata: serde_json::Value,
     /// The `solc` version.
     pub solc_version: semver::Version,
-    /// The zkVM `solc` edition.
-    pub solc_zkvm_edition: Option<semver::Version>,
+    /// The pallet revive edition.
+    pub revive_pallet_version: Option<semver::Version>,
     /// The PolkaVM compiler version.
-    pub zk_version: semver::Version,
+    pub revive_version: semver::Version,
     /// The PolkaVM compiler optimizer settings.
     pub optimizer_settings: revive_llvm_context::OptimizerSettings,
 }
@@ -23,15 +23,15 @@ impl Metadata {
     pub fn new(
         solc_metadata: serde_json::Value,
         solc_version: semver::Version,
-        solc_zkvm_edition: Option<semver::Version>,
-        zk_version: semver::Version,
+        revive_pallet_version: Option<semver::Version>,
+        revive_version: semver::Version,
         optimizer_settings: revive_llvm_context::OptimizerSettings,
     ) -> Self {
         Self {
             solc_metadata,
             solc_version,
-            solc_zkvm_edition,
-            zk_version,
+            revive_pallet_version,
+            revive_version,
             optimizer_settings,
         }
     }

--- a/crates/solidity/src/resolc/main.rs
+++ b/crates/solidity/src/resolc/main.rs
@@ -31,11 +31,9 @@ fn main_inner() -> anyhow::Result<()> {
 
     if arguments.version {
         println!(
-            "{} version {}+commit.{} (LLVM build {:?})",
+            "{} version {}",
             env!("CARGO_PKG_DESCRIPTION"),
-            env!("CARGO_PKG_VERSION"),
-            env!("GIT_COMMIT_HASH"),
-            inkwell::support::get_llvm_version(),
+            revive_solidity::ResolcVersion::default().long
         );
         return Ok(());
     }

--- a/crates/solidity/src/solc/combined_json/mod.rs
+++ b/crates/solidity/src/solc/combined_json/mod.rs
@@ -28,7 +28,7 @@ pub struct CombinedJson {
     pub version: String,
     /// The `resolc` compiler version.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub zk_version: Option<String>,
+    pub revive_version: Option<String>,
 }
 
 impl CombinedJson {

--- a/crates/solidity/src/solc/standard_json/output/mod.rs
+++ b/crates/solidity/src/solc/standard_json/output/mod.rs
@@ -45,7 +45,7 @@ pub struct Output {
     pub long_version: Option<String>,
     /// The `resolc` compiler version.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub zk_version: Option<String>,
+    pub revive_version: Option<String>,
 }
 
 impl Output {

--- a/crates/solidity/src/test_utils.rs
+++ b/crates/solidity/src/test_utils.rs
@@ -202,11 +202,7 @@ pub fn build_solidity_and_detect_missing_libraries(
     let project = output.try_to_project(sources, libraries, pipeline, &solc_version, None)?;
 
     let missing_libraries = project.get_missing_libraries();
-    missing_libraries.write_to_standard_json(
-        &mut output,
-        &solc.version()?,
-        &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
-    )?;
+    missing_libraries.write_to_standard_json(&mut output, &solc.version()?)?;
 
     Ok(output)
 }
@@ -232,14 +228,14 @@ pub fn check_solidity_warning(
     warning_substring: &str,
     libraries: BTreeMap<String, BTreeMap<String, String>>,
     pipeline: SolcPipeline,
-    skip_for_zkvm_edition: bool,
+    skip_for_revive_edition: bool,
     suppressed_warnings: Option<Vec<Warning>>,
 ) -> anyhow::Result<bool> {
     check_dependencies();
 
     let mut solc = SolcCompiler::new(SolcCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())?;
     let solc_version = solc.version()?;
-    if skip_for_zkvm_edition && solc_version.l2_revision.is_some() {
+    if skip_for_revive_edition && solc_version.l2_revision.is_some() {
         return Ok(true);
     }
 

--- a/crates/solidity/src/test_utils.rs
+++ b/crates/solidity/src/test_utils.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Mutex;
 
 use once_cell::sync::Lazy;
@@ -106,11 +105,7 @@ pub fn build_solidity_with_options(
     let project = output.try_to_project(sources, libraries, pipeline, &solc_version, None)?;
 
     let build: crate::Build = project.compile(optimizer_settings, false, None)?;
-    build.write_to_standard_json(
-        &mut output,
-        &solc_version,
-        &semver::Version::from_str(env!("CARGO_PKG_VERSION"))?,
-    )?;
+    build.write_to_standard_json(&mut output, &solc_version)?;
 
     Ok(output)
 }

--- a/crates/solidity/src/version.rs
+++ b/crates/solidity/src/version.rs
@@ -1,0 +1,25 @@
+//! The resolc compiler version.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// The resolc compiler version.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Version {
+    /// The long version string.
+    pub long: String,
+    /// The short `semver`.
+    pub default: semver::Version,
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        let default = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
+        let commit = env!("GIT_COMMIT_HASH");
+
+        Self {
+            long: format!("{default}+commit.{commit}"),
+            default,
+        }
+    }
+}

--- a/crates/solidity/src/version.rs
+++ b/crates/solidity/src/version.rs
@@ -10,16 +10,21 @@ pub struct Version {
     pub long: String,
     /// The short `semver`.
     pub default: semver::Version,
+    /// The LLVM version string.
+    pub llvm: semver::Version,
 }
 
 impl Default for Version {
     fn default() -> Self {
         let default = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid");
         let commit = env!("GIT_COMMIT_HASH");
+        let (llvm_major, llvm_minor, llvm_patch) = inkwell::support::get_llvm_version();
+        let llvm = semver::Version::new(llvm_major as u64, llvm_minor as u64, llvm_patch as u64);
 
         Self {
-            long: format!("{default}+commit.{commit}"),
+            long: format!("{default}+commit.{commit}..llvm-{llvm}"),
             default,
+            llvm,
         }
     }
 }

--- a/crates/solidity/src/version.rs
+++ b/crates/solidity/src/version.rs
@@ -22,7 +22,7 @@ impl Default for Version {
         let llvm = semver::Version::new(llvm_major as u64, llvm_minor as u64, llvm_patch as u64);
 
         Self {
-            long: format!("{default}+commit.{commit}..llvm-{llvm}"),
+            long: format!("{default}+commit.{commit}.llvm-{llvm}"),
             default,
             llvm,
         }


### PR DESCRIPTION
This PR renames the revive metadata fields and includes the commit hash in the revive version (similar to what solc does).