### PR TITLE
CI: ignore the broken test

### DIFF
--- a/crates/differential/src/lib.rs
+++ b/crates/differential/src/lib.rs
@@ -557,6 +557,7 @@ allocated bytes: 3711"#;
     }
 
     #[test]
+    #[ignore] // https://github.com/ethereum/go-ethereum/issues/30778
     fn bench_flipper() {
         let log_runtime = Evm::default()
             .code_blob(EVM_BIN_RUNTIME_FIXTURE.as_bytes().to_vec())


### PR DESCRIPTION
The older `evm` binary version is nowhere provided and we don't want to clone and build it ourselves each time. We just ignore this test for now. It is not terribly important.