### PR TITLE
Fix broken link to introduction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 YUL and EVM assembly recompiler to LLVM, targetting RISC-V on [PolkaVM](https://github.com/koute/polkavm).
 
-Visit [contracts.polkadot.io](contracts.polkadot.io) to learn more about contracts on Polkadot!
+Visit [contracts.polkadot.io](https://contracts.polkadot.io) to learn more about contracts on Polkadot!
 
 ## Status
 


### PR DESCRIPTION
This PR makes the link to [contracts.polkadot.io](https://contracts.polkadot.io) in README.md work correctly.

Currently, the rendered link points to the sub path of github repository, not introduction site.