### PR TITLE
fix the commit sha in the version string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,6 +3368,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "gloo-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,6 +4357,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,6 +4443,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4848,6 +4903,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -8126,6 +8193,7 @@ dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "git2",
  "hex",
  "inkwell",
  "libc",
@@ -11214,6 +11282,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ env_logger = { version = "0.10.0", default-features = false }
 serde_stacker = "0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 log = { version = "0.4" }
+git2 = "0.19.0"
 
 # polkadot-sdk and friends
 codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }

--- a/crates/solidity/Cargo.toml
+++ b/crates/solidity/Cargo.toml
@@ -48,6 +48,9 @@ mimalloc = { version = "*", default-features = false }
 libc = { workspace = true }
 inkwell = { workspace = true, features = ["target-riscv", "llvm18-0-no-llvm-linking"]}
 
+[build-dependencies]
+git2 = { workspace = true }
+
 [features]
 parallel = ["rayon"]
 default = ["parallel"]

--- a/crates/solidity/build.rs
+++ b/crates/solidity/build.rs
@@ -1,9 +1,7 @@
 fn main() {
-    let git_rev = std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .map(|out| String::from_utf8(out.stdout).unwrap_or_default())
-        .unwrap_or("unknown".to_owned());
-
-    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_rev.trim());
+    let repo = git2::Repository::open("../..").expect("should be a repository");
+    let head = repo.head().expect("should have head");
+    let commit = head.peel_to_commit().expect("should have commit");
+    let id = &commit.id().to_string()[..7];
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={id}");
 }


### PR DESCRIPTION
From the `git2` crate:

> The source for libgit2 is included in the libgit2-sys crate so there's no need to pre-install the libgit2 library

So it should work even if git is not installed on the build host
