### PR TITLE
calls: supply max ref_time and proof_size limits

### DIFF
--- a/crates/llvm-context/src/polkavm/evm/call.rs
+++ b/crates/llvm-context/src/polkavm/evm/call.rs
@@ -60,8 +60,8 @@ where
     let arguments = &[
         flags.as_basic_value_enum(),
         address_pointer.value.as_basic_value_enum(),
-        context.integer_const(64, 0).as_basic_value_enum(),
-        context.integer_const(64, 0).as_basic_value_enum(),
+        context.integer_const(64, u64::MAX).as_basic_value_enum(),
+        context.integer_const(64, u64::MAX).as_basic_value_enum(),
         context.sentinel_pointer().value.as_basic_value_enum(),
         value_pointer.value.as_basic_value_enum(),
         input_pointer.value.as_basic_value_enum(),
@@ -140,10 +140,10 @@ where
         flags.as_basic_value_enum(),
         address_pointer.value.as_basic_value_enum(),
         context
-            .integer_const(revive_common::BIT_LENGTH_X64, 0)
+            .integer_const(revive_common::BIT_LENGTH_X64, u64::MAX)
             .as_basic_value_enum(),
         context
-            .integer_const(revive_common::BIT_LENGTH_X64, 0)
+            .integer_const(revive_common::BIT_LENGTH_X64, u64::MAX)
             .as_basic_value_enum(),
         context.sentinel_pointer().value.as_basic_value_enum(),
         input_pointer.value.as_basic_value_enum(),


### PR DESCRIPTION
Supplying the maximum is semantically equivalent to sending 0 which indicates uncapped limits. However, the pallet will change to allow a limit of 0 proof size limit. For consistency, we just supply the maximum everywhere.