### PR TITLE
fix the CI runner version

### DIFF
--- a/.github/workflows/build-revive-debian.yml
+++ b/.github/workflows/build-revive-debian.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-revive-debian-x86:
     name: debian-container-x86
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-revive-wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-ubuntu-x86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Stick the CI runner host version: https://github.com/actions/runner-images/issues/10636

The LLVM build is expecting older dependencies. Will resolve once we have our own LLVM builds.