### PR TITLE
Adds import callback resolution to resolc compiler

### DIFF
--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -184,8 +184,9 @@ pub fn standard_output<T: Compiler>(
     if let Some(sources) = &solc_output.sources {
         for source_path in sources.keys() {
             if !source_code_files.contains_key(source_path) {
-                let source = std::fs::read_to_string(source_path)
-                    .map_err(|e| anyhow::anyhow!("Can't read source file at `{}`: {}", source_path, e))?;
+                let source = std::fs::read_to_string(source_path).map_err(|e| {
+                    anyhow::anyhow!("Can't read source file at `{}`: {}", source_path, e)
+                })?;
                 let _ = source_code_files.insert(source_path.clone(), source);
             }
         }


### PR DESCRIPTION
Resolves https://github.com/paritytech/revive/issues/98

Let me know if this looks good and I'll write NodeJS tests.

Solidity compiler exports all sources, so I just add those in our source code files.

Tested with these two files:
`test.sol`
```
// SPDX-License-Identifier: MIT

pragma solidity >=0.4.16;

import "./callable.sol";

contract Main {
    function main(Callable callable) public returns(uint) {
        return callable.f(5);
    }
}
```

`callable.sol`
```
// SPDX-License-Identifier: MIT

pragma solidity >=0.4.16;

contract Callable {
    function f(uint a) public pure returns(uint) {
        return a * 2;
    }
}
```
This is the output
```
➜  revive git:(davidk/add-import-resolution-to-resolc) ✗ resolc ./test.sol
Warning: Function state mutability can be restricted to pure
 --> ./test.sol:8:5:
  |
8 |     function main(Callable callable) public returns(uint) {
  |     ^ (Relevant source part starts here and spans across multiple lines).


Compiler run successful. No output requested. Use --asm and --bin flags.
```