### PR TITLE
Add tests for the Revive WASM version

### DIFF
--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -103,12 +103,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
             Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
             iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
             # Install Bun via Scoop
             scoop install bun
-          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+          elif [[ "${{ matrix.os }}" == "macos-12" ]]; then
             curl -fsSL https://bun.sh/install | bash
             echo "$HOME/.bun/bin" >> $GITHUB_PATH
           else

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -82,7 +82,7 @@ jobs:
     needs: build-revive-wasm
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -104,13 +104,17 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            curl -fsSL https://bun.sh/install | bash
+            Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+            iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+            # Install Bun via Scoop
+            scoop install bun
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             curl -fsSL https://bun.sh/install | bash
+            echo "$HOME/.bun/bin" >> $GITHUB_PATH
           else
             curl -fsSL https://bun.sh/install | bash
+            echo "$HOME/.bun/bin" >> $GITHUB_PATH
           fi
-          echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
       - name: Confirm Installations
         run: |

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -70,6 +70,10 @@ jobs:
           source ./emsdk/emsdk_env.sh
           make install-wasm
 
+      - name: Test revive
+        run: |
+          make test-wasm
+
       - uses: actions/upload-artifact@v4
         with:
           name: revive-wasm

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -81,3 +81,50 @@ jobs:
             ${{ env.REVIVE_WASM_INSTALL_DIR }}/resolc.js
             ${{ env.REVIVE_WASM_INSTALL_DIR }}/resolc.wasm
           retention-days: 1
+
+  test-wasm:
+    needs: build-revive-wasm
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Target Directory
+        run: mkdir -p ${{ env.REVIVE_WASM_INSTALL_DIR }}
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: revive-wasm
+          path: ${{ env.REVIVE_WASM_INSTALL_DIR }}
+
+      - name: Set Up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: |
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            curl -fsSL https://bun.sh/install | bash
+            export PATH="$HOME/.bun/bin:$PATH"
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            curl -fsSL https://bun.sh/install | bash
+            export PATH="$HOME/.bun/bin:$PATH"
+          else
+            curl -fsSL https://bun.sh/install | bash
+            export PATH="$HOME/.bun/bin:$PATH"
+          fi
+
+      - name: Confirm Installations
+        run: |
+          node --version
+          bun --version
+
+      - name: Test revive
+        run: |
+          echo "Running tests for ${{ matrix.os }}"
+          npm install
+          npm run test:wasm

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   REVIVE_WASM_INSTALL_DIR: ${{ github.workspace }}/target/wasm32-unknown-emscripten/release
   EMSCRIPTEN_VERSION: 3.1.64
+  BUN_VERSION: 1.1.43
 
 jobs:
   build-revive-wasm:
@@ -82,7 +83,7 @@ jobs:
     needs: build-revive-wasm
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -106,13 +107,13 @@ jobs:
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
           iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
-          scoop install bun
+          scoop install bun@${{ env.BUN_VERSION }}
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
       - name: Install Bun on macOS and Linux
         if: runner.os != 'Windows'
         run: |
-          curl -fsSL https://bun.sh/install | bash
+          curl -fsSL https://bun.sh/install | bash -s bun-v${{ env.BUN_VERSION }}
           echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
       - name: Confirm Installations

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -107,7 +107,7 @@ jobs:
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
           iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
           scoop install bun
-          echo "$env:USERPROFILE\scoop\apps\bun\current\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
+          Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
       - name: Install Bun on macOS and Linux
         if: runner.os != 'Windows'

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -70,10 +70,6 @@ jobs:
           source ./emsdk/emsdk_env.sh
           make install-wasm
 
-      - name: Test revive
-        run: |
-          make test-wasm
-
       - uses: actions/upload-artifact@v4
         with:
           name: revive-wasm

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -104,10 +104,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
-            Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-            iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
-            # Install Bun via Scoop
-            scoop install bun
+            pwsh -Command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; iex (new-object net.webclient).downloadstring('https://get.scoop.sh'); scoop install bun"
           elif [[ "${{ matrix.os }}" == "macos-12" ]]; then
             curl -fsSL https://bun.sh/install | bash
             echo "$HOME/.bun/bin" >> $GITHUB_PATH

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -105,14 +105,12 @@ jobs:
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             curl -fsSL https://bun.sh/install | bash
-            export PATH="$HOME/.bun/bin:$PATH"
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             curl -fsSL https://bun.sh/install | bash
-            export PATH="$HOME/.bun/bin:$PATH"
           else
             curl -fsSL https://bun.sh/install | bash
-            export PATH="$HOME/.bun/bin:$PATH"
           fi
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
       - name: Confirm Installations
         run: |

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -79,7 +79,7 @@ jobs:
           retention-days: 1
 
   test-wasm:
-    needs: build-revive-wasm
+    #needs: build-revive-wasm
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
@@ -107,6 +107,7 @@ jobs:
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
           iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
           scoop install bun
+          echo "$env:USERPROFILE\scoop\apps\bun\current\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
 
       - name: Install Bun on macOS and Linux
         if: runner.os != 'Windows'

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -79,7 +79,7 @@ jobs:
           retention-days: 1
 
   test-wasm:
-    #needs: build-revive-wasm
+    needs: build-revive-wasm
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -101,17 +101,18 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install dependencies
+      - name: Install Bun on Windows
+        if: runner.os == 'Windows'
         run: |
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
-            pwsh -Command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser; iex (new-object net.webclient).downloadstring('https://get.scoop.sh'); scoop install bun"
-          elif [[ "${{ matrix.os }}" == "macos-12" ]]; then
-            curl -fsSL https://bun.sh/install | bash
-            echo "$HOME/.bun/bin" >> $GITHUB_PATH
-          else
-            curl -fsSL https://bun.sh/install | bash
-            echo "$HOME/.bun/bin" >> $GITHUB_PATH
-          fi
+          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+          iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+          scoop install bun
+
+      - name: Install Bun on macOS and Linux
+        if: runner.os != 'Windows'
+        run: |
+          curl -fsSL https://bun.sh/install | bash
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
       - name: Confirm Installations
         run: |

--- a/.github/workflows/build-revive-wasm.yml
+++ b/.github/workflows/build-revive-wasm.yml
@@ -79,7 +79,7 @@ jobs:
             ${{ env.REVIVE_WASM_INSTALL_DIR }}/resolc.wasm
           retention-days: 1
 
-  test-wasm:
+  test-revive-wasm:
     needs: build-revive-wasm
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install format test test-solidity test-cli test-integration test-workspace clean docs docs-build
+.PHONY: install format test test-solidity test-cli test-integration test-workspace test-wasm clean docs docs-build
 
 RUSTFLAGS_EMSCRIPTEN := \
 	-C link-arg=-sEXPORTED_FUNCTIONS=_main,_free,_malloc \
@@ -25,9 +25,11 @@ install-bin:
 install-npm:
 	npm install && npm fund
 
-install-wasm:
+install-wasm: install-npm
 	RUSTFLAGS='$(RUSTFLAGS_EMSCRIPTEN)' cargo build --target wasm32-unknown-emscripten -p revive-solidity --release --no-default-features
-	npm install
+
+test-wasm: install-wasm
+	npm run test:wasm
 
 # install-revive: Build and install to the directory specified in REVIVE_INSTALL_DIR
 ifeq ($(origin REVIVE_INSTALL_DIR), undefined)

--- a/js/examples/node/revive.js
+++ b/js/examples/node/revive.js
@@ -1,0 +1,32 @@
+const soljson = require('solc/soljson');
+const createRevive = require('./resolc.js');
+
+async function compile(standardJsonInput) {
+  if (!standardJsonInput) {
+    throw new Error('Input JSON for the Solidity compiler is required.');
+  }
+
+  // Initialize the compiler
+  const compiler = createRevive();
+  compiler.soljson = soljson;
+
+  // Provide input to the compiler
+  compiler.writeToStdin(JSON.stringify(standardJsonInput));
+
+  // Run the compiler
+  compiler.callMain(['--standard-json']);
+
+  // Collect output
+  const stdout = compiler.readFromStdout();
+  const stderr = compiler.readFromStderr();
+
+  // Check for errors and throw if stderr exists
+  if (stderr) {
+    throw new Error(`Compilation failed: ${stderr}`);
+  }
+
+  // Return the output if no errors
+  return stdout;
+}
+
+module.exports = { compile };

--- a/js/examples/node/run_revive.js
+++ b/js/examples/node/run_revive.js
@@ -1,5 +1,4 @@
-const soljson = require('solc/soljson');
-const createRevive = require('./resolc.js');
+const { compile } = require('./revive.js');
 
 const compilerStandardJsonInput = {
     language: 'Solidity',
@@ -30,16 +29,8 @@ const compilerStandardJsonInput = {
   };
 
 async function runCompiler() {
-  const m = createRevive();
-  m.soljson = soljson;
-
-  // Set input data for stdin
-  m.writeToStdin(JSON.stringify(compilerStandardJsonInput));
-
-  // Compile the Solidity source code
-  let x = m.callMain(['--standard-json']);
-  console.log("Stdout: " + m.readFromStdout());
-  console.error("Stderr: " + m.readFromStderr());
+  let output = await compile(compilerStandardJsonInput)
+  console.log("Output: " + output);
 }
 
 runCompiler().catch(err => {

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
     "fetch:soljson": "wget https://binaries.soliditylang.org/wasm/soljson-v0.8.28+commit.7893614a.js -O ./examples/web/soljson.js",
     "example:web": "npm run fetch:soljson && http-server ./examples/web/",
     "example:node": "node ./examples/node/run_revive.js",
-    "test:node": "mocha ./tests",
+    "test:node": "mocha --timeout 10000 ./tests",
     "test:bun": "bun test",
     "test:all": "npm run test:node && npm run test:bun"
   },

--- a/js/package.json
+++ b/js/package.json
@@ -7,9 +7,14 @@
   "scripts": {
     "fetch:soljson": "wget https://binaries.soliditylang.org/wasm/soljson-v0.8.28+commit.7893614a.js -O ./examples/web/soljson.js",
     "example:web": "npm run fetch:soljson && http-server ./examples/web/",
-    "example:node": "node ./examples/node/run_revive.js"
+    "example:node": "node ./examples/node/run_revive.js",
+    "test:node": "mocha ./tests",
+    "test:bun": "bun test",
+    "test:all": "npm run test:node && npm run test:bun"
   },
   "devDependencies": {
-    "http-server": "^14.1.1"
+    "chai": "^5.1.2",
+    "http-server": "^14.1.1",
+    "mocha": "^11.0.1"
   }
 }

--- a/js/tests/node.test.mjs
+++ b/js/tests/node.test.mjs
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import { compile } from '../examples/node/revive.js';
+
+const validCompilerInput = {
+  language: 'Solidity',
+  sources: {
+    'MyContract.sol': {
+      content: `
+        // SPDX-License-Identifier: UNLICENSED
+        pragma solidity ^0.8.0; 
+        contract MyContract { 
+          function greet() public pure returns (string memory) { 
+            return "Hello"; 
+          } 
+        }
+      `,
+    },
+  },
+  settings: {
+    optimizer: {
+      enabled: true,
+      runs: 200,
+    },
+    outputSelection: {
+      '*': {
+        '*': ['abi', 'evm.bytecode'],
+      },
+    },
+  },
+};
+
+const invalidCompilerInput = {
+  language: 'Solidity',
+  sources: {
+    'BrokenContract.sol': {
+      content: `
+        // SPDX-License-Identifier: UNLICENSED
+        pragma solidity ^0.8.0;
+        contract BrokenContract {
+          function greet() public pure returns (string memory) {
+            return "Hello" // Missing semicolon
+          }
+        }
+      `,
+    },
+  },
+  settings: {
+    optimizer: {
+      enabled: true,
+      runs: 200,
+    },
+    outputSelection: {
+      '*': {
+        '*': ['abi', 'evm.bytecode'],
+      },
+    },
+  },
+};
+
+describe('Compile Function Tests', function () {
+  it('should successfully compile valid Solidity code', async function () {
+    const result = await compile(validCompilerInput);
+
+    // Ensure result contains compiled contract
+    expect(result).to.be.a('string');
+    const output = JSON.parse(result);
+    expect(output).to.have.property('contracts');
+    expect(output.contracts['MyContract.sol']).to.have.property('MyContract');
+    expect(output.contracts['MyContract.sol'].MyContract).to.have.property('abi');
+    expect(output.contracts['MyContract.sol'].MyContract).to.have.property('evm');
+    expect(output.contracts['MyContract.sol'].MyContract.evm).to.have.property('bytecode');
+  });
+
+  it('should throw an error for invalid Solidity code', async function () {
+    const result = await compile(invalidCompilerInput);
+    expect(result).to.be.a('string');
+    const output = JSON.parse(result);
+    expect(output).to.have.property('errors');
+    expect(output.errors).to.be.an('array');
+    expect(output.errors.length).to.be.greaterThan(0);
+    expect(output.errors[0].type).to.exist;
+    expect(output.errors[0].type).to.contain("ParserError");
+  });
+
+  it('should return missing import error for invalid imports', async function () {
+    const compilerInputWithImport = {
+      ...validCompilerInput,
+      sources: {
+        'MyContract.sol': {
+          content: `
+            // SPDX-License-Identifier: UNLICENSED
+            pragma solidity ^0.8.0; 
+            import "nonexistent/console.sol";
+            contract MyContract { 
+              function greet() public pure returns (string memory) { 
+                return "Hello"; 
+              } 
+            }
+          `,
+        },
+      },
+    };
+
+    let result = await compile(compilerInputWithImport);
+    const output = JSON.parse(result);
+    expect(output).to.have.property('errors');
+    expect(output.errors).to.be.an('array');
+    expect(output.errors.length).to.be.greaterThan(0);
+    expect(output.errors[0].message).to.exist;
+    expect(output.errors[0].message).to.include('Source "nonexistent/console.sol" not found');
+  });
+});

--- a/js/tests/node.test.mjs
+++ b/js/tests/node.test.mjs
@@ -29,34 +29,6 @@ const validCompilerInput = {
   },
 };
 
-const invalidCompilerInput = {
-  language: 'Solidity',
-  sources: {
-    'BrokenContract.sol': {
-      content: `
-        // SPDX-License-Identifier: UNLICENSED
-        pragma solidity ^0.8.0;
-        contract BrokenContract {
-          function greet() public pure returns (string memory) {
-            return "Hello" // Missing semicolon
-          }
-        }
-      `,
-    },
-  },
-  settings: {
-    optimizer: {
-      enabled: true,
-      runs: 200,
-    },
-    outputSelection: {
-      '*': {
-        '*': ['abi', 'evm.bytecode'],
-      },
-    },
-  },
-};
-
 describe('Compile Function Tests', function () {
   it('should successfully compile valid Solidity code', async function () {
     const result = await compile(validCompilerInput);
@@ -72,6 +44,24 @@ describe('Compile Function Tests', function () {
   });
 
   it('should throw an error for invalid Solidity code', async function () {
+    const invalidCompilerInput = {
+      ...validCompilerInput,
+      sources: {
+        'MyContract.sol': {
+          content: `
+            // SPDX-License-Identifier: UNLICENSED
+            pragma solidity ^0.8.0; 
+            import "nonexistent/console.sol";
+            contract MyContract { 
+              function greet() public pure returns (string memory) { 
+                return "Hello" // Missing semicolon
+              } 
+            }
+          `,
+        },
+      },
+    };
+
     const result = await compile(invalidCompilerInput);
     expect(result).to.be.a('string');
     const output = JSON.parse(result);
@@ -82,7 +72,7 @@ describe('Compile Function Tests', function () {
     expect(output.errors[0].type).to.contain("ParserError");
   });
 
-  it('should return missing import error for invalid imports', async function () {
+  it('should return not found error for missing imports', async function () {
     const compilerInputWithImport = {
       ...validCompilerInput,
       sources: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "test:cli": "npm run test -w crates/solidity/src/tests/cli-tests",
-        "test:revive": "npm run test:all -w js"
+        "test:wasm": "npm run test:all -w js"
     },
     "workspaces": [
         "crates/solidity/src/tests/cli-tests",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "test:cli": "npm run test -w crates/solidity/src/tests/cli-tests",
-        "test:revive": "npm run example:node -w js"
+        "test:revive": "npm run test:all -w js"
     },
     "workspaces": [
         "crates/solidity/src/tests/cli-tests",


### PR DESCRIPTION
Add tests for the Revive WASM version, running them on macOS, Windows, and Linux using both Bun and Node.js.