### PR TITLE
Remove the docs Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,6 @@ bench: install-bin
 	cargo criterion --all --all-features --message-format=json \
 	| criterion-table > crates/benchmarks/BENCHMARKS.md
 
-docs: docs-build
-	mdbook serve --open docs/
-
-docs-build:
-	mdbook test docs/ && mdbook build docs/
-
 clean:
 	cargo clean ; \
 	rm -rf node_modules ; \


### PR DESCRIPTION
Documentation of the contracts stack was moved into a dedicated repository.