### PR TITLE
vet workspace dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,9 @@ jobs:
           sudo apt update
           sudo apt install -y ethereum
 
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main
+
       - name: Format
         run: make format
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,14 +8209,8 @@ version = "0.1.0-dev.7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "env_logger 0.11.6",
  "hex",
- "log",
- "polkavm",
  "rayon",
- "revive-common",
- "revive-differential",
- "revive-llvm-context",
  "revive-runner",
  "revive-solidity",
  "serde",
@@ -8229,10 +8223,8 @@ name = "revive-linker"
 version = "0.1.0-dev.7"
 dependencies = [
  "anyhow",
- "inkwell",
  "libc",
  "lld-sys",
- "polkavm-common",
  "polkavm-linker",
  "revive-builtins",
  "tempfile",
@@ -8252,7 +8244,6 @@ dependencies = [
  "fs_extra",
  "log",
  "num_cpus",
- "once_cell",
  "path-slash",
  "regex",
  "serde",
@@ -8270,11 +8261,8 @@ dependencies = [
  "itertools 0.14.0",
  "md5",
  "num",
- "once_cell",
  "polkavm-common",
  "polkavm-disassembler",
- "regex",
- "revive-builtins",
  "revive-common",
  "revive-linker",
  "revive-runtime-api",
@@ -9817,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -9884,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9904,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10113,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10145,7 +10133,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "Inflector",
  "expander",
@@ -10234,7 +10222,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?rev=cb0d8544dc8828c7b5e
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 
 [[package]]
 name = "sp-storage"
@@ -10251,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10286,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -10383,7 +10371,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
+source = "git+https://github.com/paritytech/polkadot-sdk#77c78e1561bbe5ee0ecf414312bae82396ae6d11"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-core"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0713007d14d88a6edb8e248cddab783b698dbb954a28b8eee4bab21cfb7e578"
+checksum = "648275bb59110f88cc5fa9a176845e52a554ebfebac2d21220bcda8c9220f797"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e3b98c37b3218924cd1d2a8570666b89662be54e5b182643855f783ea68b33"
+checksum = "bc9138f4f0912793642d453523c3116bd5d9e11de73b70177aa7cb3e94b98ad2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -130,21 +130,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "0.3.6"
+name = "alloy-eip2930"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
  "alloy-serde",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d2a7fe5c1a9bd6793829ea21a636f30fc2b3f5d2e7418ba86d96e41dd1f460"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731ea743b3d843bc657e120fb1d1e9cc94f5dab8107e35a82125a63e6420a102"
+checksum = "24acd2f5ba97c7a320e67217274bc81fe3c3174b8e6144ec875d9d54e760e278"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -154,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788bb18e8f61d5d9340b52143f27771daf7e1dccbaf2741621d2493f9debf52e"
+checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -185,15 +226,27 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
 ]
 
 [[package]]
-name = "alloy-serde"
-version = "0.3.6"
+name = "alloy-rlp-derive"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
+checksum = "5a833d97bf8a5f0f878daf2c8451fff7de7f9de38baa5a45d936ec718d81255a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -202,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07b74d48661ab2e4b50bb5950d74dbff5e61dd8ed03bb822281b706d54ebacb"
+checksum = "8d039d267aa5cbb7732fa6ce1fd9b5e9e29368f580f80ba9d7a8450c794de4b2"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -216,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cc9c7f20b90f9be1a8f71a3d8e283a43745137b0837b1a1cb13159d37cad72"
+checksum = "620ae5eee30ee7216a38027dec34e0585c55099f827f92f50d11e3d2d3a4a954"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -234,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713b7e6dfe1cb2f55c80fb05fd22ed085a1b4e48217611365ed0ae598a74c6ac"
+checksum = "ad9f7d057e00f8c5994e4ff4492b76532c51ead39353aa2ed63f8c50c0f4d52e"
 dependencies = [
  "const-hex",
  "dunce",
@@ -249,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda2711ab2e1fb517fc6e2ffa9728c9a232e296d16810810e6957b781a1b8bc"
+checksum = "74e60b084fe1aef8acecda2743ff2d93c18ff3eb67a2d3b12f62582a1e66ef5e"
 dependencies = [
  "serde",
  "winnow",
@@ -259,15 +312,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b478bc9c0c4737a04cd976accde4df7eba0bdc0d90ad6ff43d58bc93cf79c1"
+checksum = "c1382302752cd751efd275f4d6ef65877ddf61e0e6f5ac84ef4302b79a33a31a"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
  "const-hex",
  "serde",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6917c79e837aa7b77b7a6dae9f89cbe15313ac161c4d3cfaf8909ef21f3d22d8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 1.0.0",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -317,11 +386,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -936,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1124,9 +1194,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -1177,6 +1247,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -1517,6 +1599,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,16 +1769,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "common"
@@ -2848,6 +2934,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2959,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -3023,7 +3134,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f2e425d9790201ba4af4630191feac6dcc98765b118d4d18e91d23c2353866"
 dependencies = [
- "env_logger",
+ "env_logger 0.10.2",
  "log",
 ]
 
@@ -3580,16 +3691,22 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "libgit2-sys",
  "log",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -3610,7 +3727,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "ignore",
  "walkdir",
 ]
@@ -3778,15 +3895,6 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4260,18 +4368,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4293,9 +4401,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4358,9 +4466,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",
@@ -4390,7 +4498,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -4526,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "mach"
@@ -4674,9 +4782,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -4858,6 +4966,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "object"
 version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,7 +5023,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -7658,9 +7779,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924b9a625d6df5b74b0b3cfbb5669b3f62ddf3d46a677ce12b1945471b4ae5c3"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.96",
@@ -7775,7 +7896,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -7889,7 +8010,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -8090,7 +8211,7 @@ version = "0.1.0-dev.7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "env_logger",
+ "env_logger 0.11.6",
  "hex",
  "log",
  "polkavm",
@@ -8128,10 +8249,9 @@ dependencies = [
  "assert_fs",
  "clap",
  "downloader",
- "env_logger",
+ "env_logger 0.11.6",
  "flate2",
  "fs_extra",
- "http",
  "log",
  "num_cpus",
  "once_cell",
@@ -8149,7 +8269,7 @@ dependencies = [
  "anyhow",
  "hex",
  "inkwell",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "md5",
  "num",
  "once_cell",
@@ -8163,7 +8283,6 @@ dependencies = [
  "revive-stdlib",
  "semver 1.0.24",
  "serde",
- "sha2 0.10.8",
  "sha3",
 ]
 
@@ -8198,7 +8317,6 @@ version = "0.1.0-dev.7"
 dependencies = [
  "anyhow",
  "clap",
- "colored",
  "git2",
  "hex",
  "inkwell",
@@ -8208,7 +8326,6 @@ dependencies = [
  "num",
  "once_cell",
  "path-slash",
- "rand",
  "rayon",
  "regex",
  "revive-common",
@@ -8217,7 +8334,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "which",
 ]
 
@@ -8404,7 +8521,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -8821,7 +8938,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -9702,7 +9819,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -9769,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9789,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9998,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -10030,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "Inflector",
  "expander",
@@ -10119,7 +10236,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk?rev=243b751abbb94369bbd
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 
 [[package]]
 name = "sp-storage"
@@ -10136,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10171,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -10268,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#738282a2c4127f5e6a1c8d50235ba126b9f05025"
+source = "git+https://github.com/paritytech/polkadot-sdk#d822e07d51dda41982291dc6582a8c4a34821e94"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10638,9 +10755,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e89d8bf2768d277f40573c83a02a099e96d96dd3104e13ea676194e61ac4b0"
+checksum = "b84e4d83a0a6704561302b917a932484e1cae2d8c6354c64be8b7bac1c1fe057"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -10783,6 +10900,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -11261,20 +11387,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -11286,9 +11413,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -11299,9 +11426,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11309,9 +11436,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11322,9 +11449,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-instrument"
@@ -11631,9 +11761,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11657,15 +11787,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
 dependencies = [
  "either",
- "home",
- "once_cell",
+ "env_home",
  "rustix 0.38.43",
- "windows-sys 0.48.0",
+ "winsafe",
 ]
 
 [[package]]
@@ -11961,6 +12090,12 @@ checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,56 +28,51 @@ revive-solidity = { version = "0.1.0-dev.7", path = "crates/solidity" }
 revive-stdlib = { version = "0.1.0-dev.7", path = "crates/stdlib" }
 revive-build-utils = { version = "0.1.0-dev.7", path = "crates/build-utils" }
 
-hex = "0.4"
-petgraph = "0.6"
+hex = "0.4.3"
 cc = "1.0"
-libc = "0.2"
+libc = "0.2.169"
 tempfile = "3.8"
 anyhow = "1.0"
 semver = { version = "1.0", features = [ "serde" ] }
-itertools = "0.12"
+itertools = "0.14"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
 regex = "1.10"
 once_cell = "1.19"
-num = "0.4"
+num = "0.4.3"
 sha1 = "0.10"
-sha2 = "0.10"
 sha3 = "0.10"
-md5 = "0.7"
-colored = "2.1"
-thiserror = "1.0"
-which = "5.0"
+md5 = "0.7.0"
+thiserror = "2.0"
+which = "7.0"
 path-slash = "0.2"
 rayon = "1.8"
 clap = { version = "4", default-features = false, features = ["derive"] }
-rand = "0.8"
-polkavm-common = "0.18"
-polkavm-linker = "0.18"
-polkavm-disassembler = "0.18"
-polkavm = "0.18"
-alloy-primitives = { version = "0.8", features = ["serde"] }
-alloy-sol-types = "0.8"
-alloy-genesis = "0.3"
-alloy-serde = "0.3"
-env_logger = { version = "0.10.0", default-features = false }
-serde_stacker = "0.1"
-criterion = { version = "0.5", features = ["html_reports"] }
-log = { version = "0.4" }
-git2 = { version = "0.19.0", default-features = false }
+polkavm-common = "0.18.0"
+polkavm-linker = "0.18.0"
+polkavm-disassembler = "0.18.0"
+polkavm = "0.18.0"
+alloy-primitives = { version = "0.8.19", features = ["serde"] }
+alloy-sol-types = "0.8.19"
+alloy-genesis = "0.9.2"
+alloy-serde = "0.9.2"
+env_logger = { version = "0.11.6", default-features = false }
+serde_stacker = "0.1.11"
+criterion = { version = "0.5.1", features = ["html_reports"] }
+log = { version = "0.4.25" }
+git2 = { version = "0.20.0", default-features = false }
 downloader = "0.2.8"
 flate2 = "1.0.35"
-http = "1.2.0"
 fs_extra = "1.3.0"
 num_cpus = "1"
-tar = "0.4.4"
-toml = "0.8"
+tar = "0.4.43"
+toml = "0.8.19"
 assert_cmd = "2.0.16"
 assert_fs = "1.1.2"
 
 # polkadot-sdk and friends
 codec = { version = "3.6.12", default-features = false, package = "parity-scale-codec" }
-scale-info = { version = "2.11.1", default-features = false }
+scale-info = { version = "2.11.6", default-features = false }
 polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", rev = "243b751abbb94369bbd92c83d8ab159ddfc3c556" }
 
 # llvm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install format test test-solidity test-cli test-integration test-workspace test-wasm clean install-llvm install-llvm-builder
+.PHONY: install format test test-solidity test-cli test-integration test-workspace test-wasm clean install-llvm install-llvm-builder machete
 
 RUSTFLAGS_EMSCRIPTEN := \
 	-C link-arg=-sEXPORTED_FUNCTIONS=_main,_free,_malloc \
@@ -44,7 +44,11 @@ format:
 clippy:
 	cargo clippy --all-features --workspace --tests --benches -- --deny warnings --allow dead_code
 
-test: format clippy test-cli test-workspace
+machete:
+	cargo install cargo-machete
+	cargo machete
+
+test: format clippy machete test-cli test-workspace
 
 test-integration: install-bin
 	cargo test --package revive-integration

--- a/crates/integration/Cargo.toml
+++ b/crates/integration/Cargo.toml
@@ -8,18 +8,12 @@ authors.workspace = true
 description = "revive compiler integration test cases"
 
 [dependencies]
-polkavm = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
 hex = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
 serde_json = { workspace = true }
 
 revive-solidity = { workspace = true }
-revive-differential = { workspace = true }
-revive-llvm-context = { workspace = true }
-revive-common = { workspace = true }
 revive-runner = { workspace = true }
 
 [dev-dependencies]

--- a/crates/linker/Cargo.toml
+++ b/crates/linker/Cargo.toml
@@ -8,10 +8,8 @@ authors.workspace = true
 description = "revive compiler linker utils"
 
 [dependencies]
-inkwell = { workspace = true }
 tempfile = { workspace = true }
 polkavm-linker = { workspace = true }
-polkavm-common = { workspace = true }
 libc = { workspace = true }
 anyhow = { workspace = true }
 

--- a/crates/llvm-builder/Cargo.toml
+++ b/crates/llvm-builder/Cargo.toml
@@ -32,7 +32,6 @@ tar = { workspace = true }
 flate2 = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
-once_cell = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/llvm-builder/Cargo.toml
+++ b/crates/llvm-builder/Cargo.toml
@@ -30,7 +30,6 @@ regex = { workspace = true }
 downloader = { workspace = true }
 tar = { workspace = true }
 flate2 = { workspace = true }
-http = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/llvm-context/Cargo.toml
+++ b/crates/llvm-context/Cargo.toml
@@ -22,7 +22,6 @@ regex = { workspace = true }
 once_cell = { workspace = true }
 num = { workspace = true }
 hex = { workspace = true }
-sha2 = { workspace = true }
 sha3 = { workspace = true }
 md5 = { workspace = true }
 inkwell = { workspace = true }

--- a/crates/llvm-context/Cargo.toml
+++ b/crates/llvm-context/Cargo.toml
@@ -18,8 +18,6 @@ anyhow = { workspace = true }
 semver = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-regex = { workspace = true }
-once_cell = { workspace = true }
 num = { workspace = true }
 hex = { workspace = true }
 sha3 = { workspace = true }
@@ -31,5 +29,4 @@ polkavm-common = { workspace = true }
 revive-common = { workspace = true }
 revive-runtime-api = { workspace = true }
 revive-linker = { workspace = true }
-revive-builtins = { workspace = true }
 revive-stdlib = { workspace = true }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 authors.workspace = true
 description = "Execute revive contracts in a simulated blockchain runtime"
 
+[package.metadata.cargo-machete]
+ignored = ["codec", "scale-info"]
+
 [features]
 std = ["polkadot-sdk/std"]
 default = ["solidity"]

--- a/crates/solidity/Cargo.toml
+++ b/crates/solidity/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 
 [dependencies]
 clap = { workspace = true }
-colored = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 which = { workspace = true }
@@ -30,7 +29,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 semver = { workspace = true }
 once_cell = { workspace = true }
-rand = { workspace = true }
 regex = { workspace = true }
 hex = { workspace = true }
 num = { workspace = true }
@@ -49,7 +47,7 @@ libc = { workspace = true }
 inkwell = { workspace = true, features = ["target-riscv", "llvm18-0-no-llvm-linking"]}
 
 [build-dependencies]
-git2 = { workspace = true }
+git2 = { workspace = true, default-features = false }
 
 [features]
 parallel = ["rayon"]


### PR DESCRIPTION
- Update the used workspace dependencies.
- Remove the unused workspace dependencies.
- Add the machete CI workflow.