### PR TITLE
integration: bugfix blob cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a development pre-release.
 - Missing the `--overwrite` flag emits an error instead of a warning.
 - The `resolc` executable prints the help by default.
 - Removed support for legacy EVM assembly (EVMLA) translation.
+- integration: identify cached code blobs on source code to fix potential confusions.
 
 ### Fixed
 - Solidity: Add the solc `--libraries` files to sources.

--- a/crates/solidity/src/test_utils.rs
+++ b/crates/solidity/src/test_utils.rs
@@ -29,6 +29,7 @@ const DEBUG_CONFIG: revive_llvm_context::DebugConfig =
 #[derive(Hash, PartialEq, Eq)]
 struct CachedBlob {
     contract_name: String,
+    solidity: String,
     solc_optimizer_enabled: bool,
 }
 
@@ -280,6 +281,7 @@ fn compile_evm(
 ) -> Vec<u8> {
     let id = CachedBlob {
         contract_name: contract_name.to_owned(),
+        solidity: source_code.to_owned(),
         solc_optimizer_enabled,
     };
 
@@ -323,6 +325,7 @@ pub fn compile_blob_with_options(
 ) -> Vec<u8> {
     let id = CachedBlob {
         contract_name: contract_name.to_owned(),
+        solidity: source_code.to_owned(),
         solc_optimizer_enabled,
     };
 


### PR DESCRIPTION
Prevents confusions if two tests use different contracts with the same name.