### PR TITLE
llvm-context: remove the linear memory pointer indirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This is a development pre-release.
 
 Supported `polkadot-sdk` rev: `274a781e8ca1a9432c7ec87593bd93214abbff50`
 
+### Fixed
+- A bug causing incorrect loads from the emulated EVM linear memory.
+- A missing integer truncate after switching to 64bit.
+
 ## v0.1.0-dev.10
 
 This is a development pre-release.

--- a/crates/integration/contracts/MLoad.sol
+++ b/crates/integration/contracts/MLoad.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.28;
+
+/* runner.json
+{
+    "differential": true,
+    "actions": [
+        {
+            "Instantiate": {
+                "code": {
+                    "Solidity": {
+                        "contract": "MLoad"
+                    }
+                }
+            }
+        },
+        {
+            "Call": {
+                "dest": {
+                    "Instantiated": 0
+                },
+                "data": "e2179b8e"
+            }
+        }
+    ]
+}
+*/
+
+contract MLoad {
+    constructor() payable {
+        assert(g() == 0);
+    }
+
+    function g() public payable returns (uint m) {
+        assembly {
+            m := mload(0)
+        }
+    }
+}

--- a/crates/integration/src/tests.rs
+++ b/crates/integration/src/tests.rs
@@ -55,6 +55,7 @@ test_spec!(create2, "CreateB", "Create2.sol");
 test_spec!(transfer, "Transfer", "Transfer.sol");
 test_spec!(send, "Send", "Send.sol");
 test_spec!(function_pointer, "FunctionPointer", "FunctionPointer.sol");
+test_spec!(mload, "MLoad", "MLoad.sol");
 
 fn instantiate(path: &str, contract: &str) -> Vec<SpecsAction> {
     vec![Instantiate {

--- a/crates/llvm-context/src/polkavm/const/mod.rs
+++ b/crates/llvm-context/src/polkavm/const/mod.rs
@@ -6,14 +6,8 @@ pub const LLVM_VERSION: semver::Version = semver::Version::new(18, 1, 4);
 /// The pointer width sized type.
 pub static XLEN: usize = revive_common::BIT_LENGTH_X32;
 
-/// The heap memory pointer pointer global variable name.
-pub static GLOBAL_HEAP_MEMORY_POINTER: &str = "memory_pointer";
-
 /// The calldata size global variable name.
 pub static GLOBAL_CALLDATA_SIZE: &str = "calldatasize";
-
-/// The call flags global variable name.
-pub static GLOBAL_CALL_FLAGS: &str = "call_flags";
 
 /// The deployer call header size that consists of:
 /// - bytecode hash (32 bytes)

--- a/crates/runtime-api/src/lib.rs
+++ b/crates/runtime-api/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate vendors the [PolkaVM][0] C API and provides a LLVM module for interacting
 //! with the `pallet-revive` runtime API.
-//! At present, the contracts pallet requires blobs to export `call` and `deploy`,
+//! At present, the revive pallet requires blobs to export `call` and `deploy`,
 //! and offers a bunch of [runtime API methods][1]. The provided [module] implements
 //! those exports and imports.
 //! [0]: [https://crates.io/crates/polkavm]

--- a/crates/runtime-api/src/lib.rs
+++ b/crates/runtime-api/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate vendors the [PolkaVM][0] C API and provides a LLVM module for interacting
 //! with the `pallet-revive` runtime API.
-//! At present, the revive pallet requires blobs to export `call` and `deploy`,
+//! At present, the contracts pallet requires blobs to export `call` and `deploy`,
 //! and offers a bunch of [runtime API methods][1]. The provided [module] implements
 //! those exports and imports.
 //! [0]: [https://crates.io/crates/polkavm]

--- a/crates/runtime-api/src/polkavm_imports.c
+++ b/crates/runtime-api/src/polkavm_imports.c
@@ -8,10 +8,10 @@
 #define EVM_WORD_SIZE 32
 #define ALIGN(size) ((size + EVM_WORD_SIZE - 1) & ~(EVM_WORD_SIZE - 1))
 #define MAX_MEMORY_SIZE (64 * 1024)
-static char __memory[MAX_MEMORY_SIZE];
-static uint32_t __memory_size = 0;
+char __memory[MAX_MEMORY_SIZE];
+uint32_t __memory_size = 0;
 
-void *  __sbrk_internal(uint32_t offset, uint32_t size) {
+void * __sbrk_internal(uint32_t offset, uint32_t size) {
     if (offset >= MAX_MEMORY_SIZE || size > MAX_MEMORY_SIZE) {
         return NULL;
     }
@@ -25,10 +25,6 @@ void *  __sbrk_internal(uint32_t offset, uint32_t size) {
     }
 
     return (void *)&__memory[__memory_size];
-}
-
-uint32_t __msize() {
-    return __memory_size;
 }
 
 void * memset(void *b, int c, size_t len) {

--- a/crates/runtime-api/src/polkavm_imports.rs
+++ b/crates/runtime-api/src/polkavm_imports.rs
@@ -1,18 +1,14 @@
-//! This crate vendors the [PolkaVM][0] C API and provides a LLVM module for interacting
-//! with the `pallet-revive` runtime API.
-//! At present, the revive pallet requires blobs to export `call` and `deploy`,
-//! and offers a bunch of [runtime API methods][1]. The provided [module] implements
-//! those exports and imports.
-//! [0]: [https://crates.io/crates/polkavm]
-//! [1]: [https://docs.rs/pallet-contracts/26.0.0/pallet_contracts/api_doc/index.html]
-
 use inkwell::{context::Context, memory_buffer::MemoryBuffer, module::Module, support::LLVMString};
 
 include!(concat!(env!("OUT_DIR"), "/polkavm_imports.rs"));
 
-pub static SBRK: &str = "__sbrk_internal";
+/// The emulated EVM heap memory global symbol.
+pub static MEMORY: &str = "__memory";
 
-pub static MEMORY_SIZE: &str = "__msize";
+/// The emulated EVM heap memory size global symbol.
+pub static MEMORY_SIZE: &str = "__memory_size";
+
+pub static SBRK: &str = "__sbrk_internal";
 
 pub static ADDRESS: &str = "address";
 
@@ -82,9 +78,8 @@ pub static WEIGHT_TO_FEE: &str = "weight_to_fee";
 
 /// All imported runtime API symbols.
 /// Useful for configuring common attributes and linkage.
-pub static IMPORTS: [&str; 35] = [
+pub static IMPORTS: [&str; 34] = [
     SBRK,
-    MEMORY_SIZE,
     ADDRESS,
     BALANCE,
     BALANCE_OF,


### PR DESCRIPTION
Since we are emulating the EVM linear memory heap anyways we can access it directly. Fixes a bug in the old logic as a side effect. Drive-by fixes a missing integer truncate.

Closes #195
Closes #203