### PR TITLE
ci: use upstream evm for tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,10 +32,9 @@ jobs:
 
       - name: Install geth
         run: |
-          git clone https://github.com/xermicus/go-ethereum --branch=cl/fix-runner-state-dump --depth=1
-          cd go-ethereum
-          make all
-          echo "$(pwd)/build/bin/" >> $GITHUB_PATH
+          sudo add-apt-repository -y ppa:ethereum/ethereum
+          sudo apt update
+          sudo apt install -y ethereum
 
       - name: Machete
         uses: bnjbvr/cargo-machete@main


### PR DESCRIPTION
The new release fixes a bug in the `evm` runner utility so we should be good again.