### PR TITLE
Using workflow_dispatch for LLVM releases

### DIFF
--- a/.github/workflows/release-llvm.yml
+++ b/.github/workflows/release-llvm.yml
@@ -1,9 +1,12 @@
 name: Release LLVM
 
 on:
-  push:
-    tags:
-      - "llvm*"
+  workflow_dispatch:
+    inputs:
+      llvm_version:
+        type: string
+        required: true
+        description: llvm version in "x.x.x" format, e.g. "18.1.8"
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,13 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.resolve-version.outputs.version }}
     steps:
+      - id: resolve-version
+        run: |
+          echo "version=${{ inputs.llvm_version }}-revive.${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+
       - name: create release
         uses: softprops/action-gh-release@v2
         with:
-          name: "LLVM binaries release: ${{ github.ref_name }}"
+          name: "LLVM binaries release: ${{ steps.resolve-version.outputs.version }}"
           body: "This release includes binaries of LLVM, used to compile revive itself"
           make_latest: "false"
+          tag_name: ${{ steps.resolve-version.outputs.version }}
 
   build-macos:
     strategy:
@@ -68,14 +78,15 @@ jobs:
 
       - name: package artifacts
         run: |
-          tar -czf "${{ github.ref_name }}-macos-${{ matrix.arch }}.tar.gz" target-llvm/gnu/target-final
+          tar -czf "${{ needs.create-release.outputs.version }}-macos-${{ matrix.arch }}.tar.gz" target-llvm/gnu/target-final
 
       - name: upload archive to release
         uses: softprops/action-gh-release@v2
         with:
           make_latest: "false"
+          tag_name: ${{ needs.create-release.outputs.version }}
           files: |
-            ${{ github.ref_name }}-macos-${{ matrix.arch }}.tar.gz
+            ${{ needs.create-release.outputs.version }}-macos-${{ matrix.arch }}.tar.gz
 
 
   build-linux-all:
@@ -141,15 +152,16 @@ jobs:
 
       - name: package artifacts
         run: |
-          tar -czf "${{ github.ref_name }}-x86_64-linux-gnu-linux.tar.gz" target-llvm/gnu/target-final
-          tar -czf "${{ github.ref_name }}-x86_64-linux-musl.tar.gz" target-llvm/musl/target-final
-          tar -czf "${{ github.ref_name }}-wasm32-unknown-emscripten.tar.gz" target-llvm/emscripten/target-final
+          tar -czf "${{ needs.create-release.outputs.version }}-x86_64-linux-gnu-linux.tar.gz" target-llvm/gnu/target-final
+          tar -czf "${{ needs.create-release.outputs.version }}-x86_64-linux-musl.tar.gz" target-llvm/musl/target-final
+          tar -czf "${{ needs.create-release.outputs.version }}-wasm32-unknown-emscripten.tar.gz" target-llvm/emscripten/target-final
 
       - name: upload archive to release
         uses: softprops/action-gh-release@v2
         with:
           make_latest: "false"
+          tag_name: ${{ needs.create-release.outputs.version }}
           files: |
-            ${{ github.ref_name }}-x86_64-linux-gnu-linux.tar.gz
-            ${{ github.ref_name }}-x86_64-linux-musl.tar.gz
-            ${{ github.ref_name }}-wasm32-unknown-emscripten.tar.gz
+            ${{ needs.create-release.outputs.version }}-x86_64-linux-gnu-linux.tar.gz
+            ${{ needs.create-release.outputs.version }}-x86_64-linux-musl.tar.gz
+            ${{ needs.create-release.outputs.version }}-wasm32-unknown-emscripten.tar.gz

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@ To create a new pre-release:
 
 # LLVM release
 
-To create a new LLVM release, create a git tag (not GitHub release) with `llvm-` prefix, e.g. `llvm-0.0.11`.  
-`Release LLVM` action will start automatically. It will create new GitHub release, and upload LLVM binaries.  
-Other actions including Release will use these binaries on the next run.
+To create a new LLVM release, run "Release LLVM" workflow. Use current LLVM version as parameter, e.g. `18.1.8`.
+Version suffix will be resolved automatically.  
+The workflows will create new GitHub release, and upload LLVM binaries.
+Next release of resolc will use newly created binaries.  


### PR DESCRIPTION
Workflow example: https://github.com/paritytech/revive-workflow-test/actions/runs/13440400860
Release example: https://github.com/paritytech/revive-workflow-test/releases/tag/18.1.8-revive.395212b