### PR TITLE
ci: fix the llvm release tag

### DIFF
--- a/.github/workflows/release-llvm.yml
+++ b/.github/workflows/release-llvm.yml
@@ -29,7 +29,7 @@ jobs:
           name: "LLVM binaries release: ${{ steps.resolve-version.outputs.version }}"
           body: "This release includes binaries of LLVM, used to compile revive itself"
           make_latest: "false"
-          tag_name: ${{ steps.resolve-version.outputs.version }}
+          tag_name: "llvm-${{ steps.resolve-version.outputs.version }}"
 
   build-macos:
     strategy:


### PR DESCRIPTION
Another afterburner for the LLVM release, should prevent this: https://github.com/paritytech/revive/actions/runs/13454276537/job/37594743538