### PR TITLE
Fix: add llvm- prefix to llvm version tag

### DIFF
--- a/.github/workflows/release-llvm.yml
+++ b/.github/workflows/release-llvm.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - id: resolve-version
         run: |
-          echo "version=${{ inputs.llvm_version }}-revive.${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "version=llvm-${{ inputs.llvm_version }}-revive.${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
 
       - name: create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Needed both for differentiating them from regular releases and for
filtering the tags in automation
