### PR TITLE
llvm-builder: only run expensive tests on linux

### DIFF
--- a/crates/llvm-builder/tests/build.rs
+++ b/crates/llvm-builder/tests/build.rs
@@ -83,6 +83,7 @@ fn clone_build_and_clean_musl() -> anyhow::Result<()> {
 /// This test verifies that the LLVM repository can be successfully cloned and built in debug mode
 /// with tests and coverage enabled.
 #[test]
+#[cfg(target_os = "linux")]
 fn debug_build_with_tests_coverage() -> anyhow::Result<()> {
     let test_dir = common::TestDir::with_lockfile(None)?;
 
@@ -107,6 +108,7 @@ fn debug_build_with_tests_coverage() -> anyhow::Result<()> {
 
 /// This test verifies that the LLVM repository can be successfully built with address sanitizer.
 #[test]
+#[cfg(target_os = "linux")]
 fn build_with_sanitizers() -> anyhow::Result<()> {
     let test_dir = common::TestDir::with_lockfile(None)?;
 
@@ -129,7 +131,7 @@ fn build_with_sanitizers() -> anyhow::Result<()> {
 
 /// Tests the clone, build, and clean process of the LLVM repository for the emscripten target.
 #[test]
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux"))]
 fn clone_build_and_clean_emscripten() -> anyhow::Result<()> {
     let test_dir = common::TestDir::with_lockfile(None)?;
     let command = Command::cargo_bin(common::REVIVE_LLVM)?;


### PR DESCRIPTION
The tests are supposed to keep trouble on release CI jobs - which run mostly on linux. So there is no need to do all these expensive tests on all plattforms.

The emscripten build is supposed to work well on MacOS because that's what most devs use - but not the CI so if it's broken we can just figure and fix it when issues arise.