### PR TITLE
Add per file output selection for `--standard-json` mode and some other small foundry support bits.

### DIFF
--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,10 +1,10 @@
 {
-  "Baseline": 1110,
-  "Computation": 2389,
-  "DivisionArithmetics": 14822,
-  "ERC20": 23973,
-  "Events": 1605,
-  "FibonacciIterative": 2023,
-  "Flipper": 1989,
-  "SHA1": 17026
+  "Baseline": 1237,
+  "Computation": 3119,
+  "DivisionArithmetics": 16561,
+  "ERC20": 23966,
+  "Events": 2102,
+  "FibonacciIterative": 2521,
+  "Flipper": 2745,
+  "SHA1": 17004
 }

--- a/crates/solidity/src/solc/standard_json/input/settings/selection/file/flag.rs
+++ b/crates/solidity/src/solc/standard_json/input/settings/selection/file/flag.rs
@@ -43,9 +43,6 @@ pub enum Flag {
     /// The Ir
     #[serde(rename = "ir")]
     Ir,
-    // Catch all unsupported flags
-    #[serde(other)]
-    Unknown,
 }
 
 impl std::fmt::Display for Flag {
@@ -64,7 +61,6 @@ impl std::fmt::Display for Flag {
             Self::EVMDBC => write!(f, "evm.deployedBytecode"),
             Self::Assembly => write!(f, "evm.assembly"),
             Self::Ir => write!(f, "ir"),
-            Self::Unknown => write!(f, "unknown flag"),
         }
     }
 }

--- a/crates/solidity/src/solc/standard_json/input/settings/selection/file/flag.rs
+++ b/crates/solidity/src/solc/standard_json/input/settings/selection/file/flag.rs
@@ -43,7 +43,7 @@ pub enum Flag {
     /// The Ir
     #[serde(rename = "ir")]
     Ir,
-    // Catch all unsupported functions
+    // Catch all unsupported flags
     #[serde(other)]
     Unknown,
 }

--- a/crates/solidity/src/solc/standard_json/input/settings/selection/file/flag.rs
+++ b/crates/solidity/src/solc/standard_json/input/settings/selection/file/flag.rs
@@ -40,6 +40,12 @@ pub enum Flag {
     /// The assembly code
     #[serde(rename = "evm.assembly")]
     Assembly,
+    /// The Ir
+    #[serde(rename = "ir")]
+    Ir,
+    // Catch all unsupported functions
+    #[serde(other)]
+    Unknown,
 }
 
 impl std::fmt::Display for Flag {
@@ -57,6 +63,8 @@ impl std::fmt::Display for Flag {
             Self::EVMBC => write!(f, "evm.bytecode"),
             Self::EVMDBC => write!(f, "evm.deployedBytecode"),
             Self::Assembly => write!(f, "evm.assembly"),
+            Self::Ir => write!(f, "ir"),
+            Self::Unknown => write!(f, "unknown flag"),
         }
     }
 }

--- a/crates/solidity/src/solc/standard_json/input/settings/selection/file/mod.rs
+++ b/crates/solidity/src/solc/standard_json/input/settings/selection/file/mod.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use self::flag::Flag as SelectionFlag;
 
 /// The `solc --standard-json` output file selection.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct File {
     /// The per-file output selections.
     #[serde(rename = "", skip_serializing_if = "Option::is_none")]
@@ -39,12 +39,14 @@ impl File {
     pub fn extend_with_required(&mut self) -> &mut Self {
         let required = Self::new_required();
 
-        self.per_file
-            .get_or_insert_with(HashSet::default)
-            .extend(required.per_file.unwrap_or_default());
-        self.per_contract
-            .get_or_insert_with(HashSet::default)
-            .extend(required.per_contract.unwrap_or_default());
+        let set = self.per_file.get_or_insert_with(HashSet::default);
+        set.remove(&SelectionFlag::Unknown);
+        set.extend(required.per_file.unwrap_or_default());
+
+        let set = self.per_contract.get_or_insert_with(HashSet::default);
+        set.remove(&SelectionFlag::Unknown);
+        set.extend(required.per_contract.unwrap_or_default());
+
         self
     }
 }

--- a/crates/solidity/src/solc/standard_json/input/settings/selection/file/mod.rs
+++ b/crates/solidity/src/solc/standard_json/input/settings/selection/file/mod.rs
@@ -39,13 +39,12 @@ impl File {
     pub fn extend_with_required(&mut self) -> &mut Self {
         let required = Self::new_required();
 
-        let set = self.per_file.get_or_insert_with(HashSet::default);
-        set.remove(&SelectionFlag::Unknown);
-        set.extend(required.per_file.unwrap_or_default());
-
-        let set = self.per_contract.get_or_insert_with(HashSet::default);
-        set.remove(&SelectionFlag::Unknown);
-        set.extend(required.per_contract.unwrap_or_default());
+        self.per_file
+            .get_or_insert_with(HashSet::default)
+            .extend(required.per_file.unwrap_or_default());
+        self.per_contract
+            .get_or_insert_with(HashSet::default)
+            .extend(required.per_contract.unwrap_or_default());
 
         self
     }

--- a/crates/solidity/src/solc/standard_json/input/settings/selection/mod.rs
+++ b/crates/solidity/src/solc/standard_json/input/settings/selection/mod.rs
@@ -2,17 +2,22 @@
 
 pub mod file;
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 use serde::Serialize;
 
 use self::file::File as FileSelection;
 
 /// The `solc --standard-json` output selection.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
 pub struct Selection {
     /// Only the 'all' wildcard is available for robustness reasons.
     #[serde(rename = "*", skip_serializing_if = "Option::is_none")]
-    pub all: Option<FileSelection>,
+    all: Option<FileSelection>,
+
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", flatten)]
+    pub files: BTreeMap<String, FileSelection>,
 }
 
 impl Selection {
@@ -20,6 +25,7 @@ impl Selection {
     pub fn new_required() -> Self {
         Self {
             all: Some(FileSelection::new_required()),
+            files: BTreeMap::new(),
         }
     }
 
@@ -28,6 +34,66 @@ impl Selection {
         self.all
             .get_or_insert_with(FileSelection::new_required)
             .extend_with_required();
+        for (_, v) in self.files.iter_mut() {
+            v.extend_with_required();
+        }
         self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use crate::SolcStandardJsonInputSettingsSelectionFile;
+
+    use super::Selection;
+
+    #[test]
+    fn per_file() {
+        let init = Selection {
+            all: None,
+            files: BTreeMap::from([(
+                "Test".to_owned(),
+                SolcStandardJsonInputSettingsSelectionFile::new_required(),
+            )]),
+        };
+
+        let deser = serde_json::to_string(&init)
+            .and_then(|string| serde_json::from_str(&string))
+            .unwrap();
+
+        assert_eq!(init, deser)
+    }
+
+    #[test]
+    fn all() {
+        let init = Selection {
+            all: Some(SolcStandardJsonInputSettingsSelectionFile::new_required()),
+            files: BTreeMap::new(),
+        };
+
+        let deser = serde_json::to_string(&init)
+            .and_then(|string| serde_json::from_str(&string))
+            .unwrap();
+
+        assert_eq!(init, deser)
+    }
+
+    #[test]
+    fn all_and_override() {
+        let init = Selection {
+            all: Some(SolcStandardJsonInputSettingsSelectionFile::new_required()),
+            files: BTreeMap::from([(
+                "Test".to_owned(),
+                SolcStandardJsonInputSettingsSelectionFile::new_required(),
+            )]),
+        };
+
+        let deser = serde_json::to_string(&init)
+            .and_then(|string| serde_json::from_str(&string))
+            .unwrap();
+
+        assert_eq!(init, deser)
     }
 }

--- a/crates/solidity/src/solc/standard_json/output/contract/mod.rs
+++ b/crates/solidity/src/solc/standard_json/output/contract/mod.rs
@@ -32,6 +32,9 @@ pub struct Contract {
     /// Contract's bytecode and related objects
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evm: Option<EVM>,
+    /// The contract IR code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ir: Option<String>,
     /// The contract optimized IR code.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ir_optimized: Option<String>,


### PR DESCRIPTION
### Description

This PR adds per file support for output selection in `--standard-json` inputs this is needed for foundry support. 

This PR also adds `Ir` and `Unknown` flags to the output selection options, ir for the unoptimized IR and `Unknown` to catch unsupported options as they would not be applied anyways.(Although on take 2 it seems like it's better to error out explicitely rather than drop unsupported flags.)