### PR TITLE
Fixing revive release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: compress macos artifact
         run: |
+          chmod +x resolc-macos
           tar -czf resolc-macos.tar.gz ./resolc-macos
 
       - uses: actions/upload-artifact@v4
@@ -212,7 +213,7 @@ jobs:
 
       - name: compress musl artifact
         run: |
-          tar --strip-components 1 -czf resolc-static-linux.tar.gz ./resolc-out/resolc-static-linux
+          tar --strip-components 2 -czf resolc-static-linux.tar.gz ./resolc-out/resolc-static-linux
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
 
       - name: compress wasm artifact
         run: |
-          tar --strip-components 3 -czf resolc-wasm.tar.gz \
+          tar --strip-components 4 -czf resolc-wasm.tar.gz \
             ./target/wasm32-unknown-emscripten/release/resolc.js \
             ./target/wasm32-unknown-emscripten/release/resolc.wasm \
             ./target/wasm32-unknown-emscripten/release/resolc_web.js


### PR DESCRIPTION
* Stripping "./resolc-out" from linux artifact is weirdly
`--strip-components 2`, not `1`
* Adding execution bit for macos binary
