### PR TITLE
Add --supported-solc-versions CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Supported `polkadot-sdk` rev:`c29e72a8628835e34deb6aa7db9a78a2e4eabcee`
 
 ### Added
 - Support for solc v0.8.29
+- `--supported-solc-versions` for `resolc` binary to return a `semver` range of supported `solc` versions.
 
 ### Changed
 - Runner `resolc` using webkit is no longer supported.

--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -46,6 +46,9 @@ pub use self::solc::version::Version as SolcVersion;
 pub use self::solc::Compiler;
 pub use self::version::Version as ResolcVersion;
 pub use self::warning::Warning;
+
+pub use solc::{FIRST_SUPPORTED_VERSION, LAST_SUPPORTED_VERSION};
+
 #[cfg(not(target_os = "emscripten"))]
 pub mod test_utils;
 pub mod tests;

--- a/crates/solidity/src/lib.rs
+++ b/crates/solidity/src/lib.rs
@@ -44,10 +44,10 @@ pub use self::solc::standard_json::output::contract::Contract as SolcStandardJso
 pub use self::solc::standard_json::output::Output as SolcStandardJsonOutput;
 pub use self::solc::version::Version as SolcVersion;
 pub use self::solc::Compiler;
+pub use self::solc::FIRST_SUPPORTED_VERSION as SolcFirstSupportedVersion;
+pub use self::solc::LAST_SUPPORTED_VERSION as SolcLastSupportedVersion;
 pub use self::version::Version as ResolcVersion;
 pub use self::warning::Warning;
-
-pub use solc::{FIRST_SUPPORTED_VERSION, LAST_SUPPORTED_VERSION};
 
 #[cfg(not(target_os = "emscripten"))]
 pub mod test_utils;

--- a/crates/solidity/src/resolc/arguments.rs
+++ b/crates/solidity/src/resolc/arguments.rs
@@ -19,6 +19,10 @@ pub struct Arguments {
     #[arg(long = "version")]
     pub version: bool,
 
+    /// Print supported `solc` versions and exit.
+    #[arg(long = "supported-solc-versions")]
+    pub supported_solc_versions: bool,
+
     /// Print the licence and exit.
     #[arg(long = "license")]
     pub license: bool,
@@ -169,6 +173,12 @@ impl Arguments {
     pub fn validate(&self) -> anyhow::Result<()> {
         if self.version && std::env::args().count() > 2 {
             anyhow::bail!("No other options are allowed while getting the compiler version.");
+        }
+
+        if self.supported_solc_versions && std::env::args().count() > 2 {
+            anyhow::bail!(
+                "No other options are allowed while getting the supported `solc` versions."
+            );
         }
 
         #[cfg(debug_assertions)]

--- a/crates/solidity/src/resolc/main.rs
+++ b/crates/solidity/src/resolc/main.rs
@@ -41,6 +41,16 @@ fn main_inner() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if arguments.supported_solc_versions {
+        writeln!(
+            std::io::stdout(),
+            ">={},<={}",
+            revive_solidity::FIRST_SUPPORTED_VERSION,
+            revive_solidity::LAST_SUPPORTED_VERSION,
+        )?;
+        return Ok(());
+    }
+
     if arguments.license {
         let license_mit = include_str!("../../../../LICENSE-MIT");
         let license_apache = include_str!("../../../../LICENSE-APACHE");

--- a/crates/solidity/src/resolc/main.rs
+++ b/crates/solidity/src/resolc/main.rs
@@ -45,8 +45,8 @@ fn main_inner() -> anyhow::Result<()> {
         writeln!(
             std::io::stdout(),
             ">={},<={}",
-            revive_solidity::FIRST_SUPPORTED_VERSION,
-            revive_solidity::LAST_SUPPORTED_VERSION,
+            revive_solidity::SolcFirstSupportedVersion,
+            revive_solidity::SolcLastSupportedVersion,
         )?;
         return Ok(());
     }


### PR DESCRIPTION
### Description 

Adds `--supported-solc-versions` cli command to return a semver range of supported `solc` versions. 
Is a hack until #162 is implemented.  

