### PR TITLE
Support solc v0.8.29

### DIFF
--- a/.github/actions/get-solc/action.yml
+++ b/.github/actions/get-solc/action.yml
@@ -1,4 +1,5 @@
 name: "Install Solidity Compiler"
+description: "Installs the Ethereum solc Solidity compiler frontend executable"
 
 runs:
   using: "composite"
@@ -18,7 +19,7 @@ runs:
       shell: bash
       run: |
         mkdir -p solc
-        curl -sSL --output solc/solc https://github.com/ethereum/solidity/releases/download/v0.8.28/${SOLC_NAME}
+        curl -sSL --output solc/solc https://github.com/ethereum/solidity/releases/download/v0.8.29/${SOLC_NAME}
 
     - name: Make Solc Executable
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-    types: [opened, synchronize, labled, unlabled]
+    types: [opened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 concurrency:
@@ -62,7 +62,13 @@ jobs:
   build:
     strategy:
       matrix:
-        target: [x86_64-unknown-linux-musl, aarch64-apple-darwin, x86_64-apple-darwin, x86_64-pc-windows-msvc]
+        target:
+          [
+            x86_64-unknown-linux-musl,
+            aarch64-apple-darwin,
+            x86_64-apple-darwin,
+            x86_64-pc-windows-msvc,
+          ]
         include:
           - target: x86_64-unknown-linux-musl
             type: musl
@@ -83,7 +89,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-        # without this it will override our rust flags
+          # without this it will override our rust flags
           rustflags: ""
           cache-key: ${{ matrix.target }}
 
@@ -165,12 +171,12 @@ jobs:
       - name: Set Up Node.js
         uses: actions/setup-node@v3
         with:
-         node-version: "20"
+          node-version: "20"
 
       - name: Basic Sanity Check
         run: |
           mkdir -p solc
-          curl -sSLo solc/soljson.js https://github.com/ethereum/solidity/releases/download/v0.8.28/soljson.js
+          curl -sSLo solc/soljson.js https://github.com/ethereum/solidity/releases/download/v0.8.29/soljson.js
           node -e "
           const soljson = require('solc/soljson');
           const createRevive = require('./target/wasm32-unknown-emscripten/release/resolc.js');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This is a development pre-release.
 
 Supported `polkadot-sdk` rev:`c29e72a8628835e34deb6aa7db9a78a2e4eabcee`
 
+### Added
+- Support for solc v0.8.29
+
+### Changed
+
+### Fixed
+
 ## v0.1.0-dev.12
 
 This is a development pre-release.

--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -2,7 +2,7 @@
   "Baseline": 1443,
   "Computation": 2788,
   "DivisionArithmetics": 9748,
-  "ERC20": 19203,
+  "ERC20": 19200,
   "Events": 2201,
   "FibonacciIterative": 2041,
   "Flipper": 2632,

--- a/crates/integration/contracts/LayoutAt.sol
+++ b/crates/integration/contracts/LayoutAt.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.29;
+
+/* runner.json
+{
+    "differential": true,
+    "actions": [
+        {
+            "Instantiate": {
+                "code": {
+                    "Solidity": {
+                        "contract": "LayoutAt"
+                    }
+                }
+            }
+        },
+        {
+            "Call": {
+                "dest": {
+                    "Instantiated": 0
+                },
+                "data": "a7a0d537"
+            }
+        },
+        {
+            "Call": {
+                "dest": {
+                    "Instantiated": 0
+                },
+                "data": "15393349"
+            }
+        }
+    ]
+}
+*/
+
+contract LayoutAt layout at 0xDEADBEEF + 0xCAFEBABE {
+    uint[3] public something;
+
+    constructor() payable {
+        something[0] = 1337;
+        something[1] = 42;
+        something[2] = 69;
+    }
+
+    function slotOfSomething() public pure returns (uint ret) {
+        assembly {
+            ret := something.slot
+        }
+    }
+}

--- a/crates/integration/src/tests.rs
+++ b/crates/integration/src/tests.rs
@@ -59,6 +59,7 @@ test_spec!(function_pointer, "FunctionPointer", "FunctionPointer.sol");
 test_spec!(mload, "MLoad", "MLoad.sol");
 test_spec!(delegate_no_contract, "DelegateCaller", "DelegateCaller.sol");
 test_spec!(function_type, "FunctionType", "FunctionType.sol");
+test_spec!(layout_at, "LayoutAt", "LayoutAt.sol");
 
 fn instantiate(path: &str, contract: &str) -> Vec<SpecsAction> {
     vec![Instantiate {

--- a/crates/solidity/src/solc/mod.rs
+++ b/crates/solidity/src/solc/mod.rs
@@ -20,7 +20,7 @@ use self::version::Version;
 pub const FIRST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 0);
 
 /// The last supported version of `solc`.
-pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 28);
+pub const LAST_SUPPORTED_VERSION: semver::Version = semver::Version::new(0, 8, 29);
 
 /// `--include-path` was introduced in solc `0.8.8` <https://github.com/ethereum/solidity/releases/tag/v0.8.8>
 pub const FIRST_INCLUDE_PATH_VERSION: semver::Version = semver::Version::new(0, 8, 8);

--- a/js/build.js
+++ b/js/build.js
@@ -3,7 +3,7 @@ const path = require("path");
 const { minify } = require("terser");
 
 const SOLJSON_URI =
-  "https://binaries.soliditylang.org/wasm/soljson-v0.8.29+commit.ab55807c.js:";
+  "https://binaries.soliditylang.org/wasm/soljson-v0.8.29+commit.ab55807c.js";
 const RESOLC_WASM_URI = "http://127.0.0.1:8080/resolc.wasm";
 const RESOLC_WASM_TARGET_DIR = path.join(
   __dirname,

--- a/js/build.js
+++ b/js/build.js
@@ -3,7 +3,7 @@ const path = require("path");
 const { minify } = require("terser");
 
 const SOLJSON_URI =
-  "https://binaries.soliditylang.org/wasm/soljson-v0.8.28+commit.7893614a.js";
+  "https://binaries.soliditylang.org/wasm/soljson-v0.8.29+commit.ab55807c.js:";
 const RESOLC_WASM_URI = "http://127.0.0.1:8080/resolc.wasm";
 const RESOLC_WASM_TARGET_DIR = path.join(
   __dirname,

--- a/js/package.json
+++ b/js/package.json
@@ -2,7 +2,7 @@
   "name": "revive",
   "private": true,
   "dependencies": {
-    "solc": "^0.8.28"
+    "solc": "^0.8.29"
   },
   "scripts": {
     "example:web": "http-server ./examples/web/",


### PR DESCRIPTION
No observable changes w.r.t. YUL compilation.
- Mark solc v0.8.29 as the latest supported version
- Add integration test for solc v0.8.29 specific feature
- Use the latest version on CI
- Drive-by fix linter complaints and a two types in the CI yaml files