### PR TITLE
revive-runner: add a utility binary for local contract execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a development pre-release.
 Supported `polkadot-sdk` rev:`c29e72a8628835e34deb6aa7db9a78a2e4eabcee`
 
 ### Added
+- The `revive-runner` helper utility binary which helps to run contracts locally without a blockchain node. 
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8387,6 +8387,9 @@ name = "revive-runner"
 version = "0.1.0-dev.13"
 dependencies = [
  "alloy-primitives",
+ "anyhow",
+ "clap",
+ "env_logger 0.11.6",
  "hex",
  "parity-scale-codec",
  "polkadot-sdk 0.1.0",

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-llvm: install-llvm-builder
 	revive-llvm clone
 	revive-llvm build --llvm-projects lld --llvm-projects clang
 
-install-revive-runner: install-revive-runner
+install-revive-runner:
 	cargo install --path crates/runner --no-default-features
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 	install-wasm \
 	install-llvm-builder \
 	install-llvm \
+	install-revive-runner \
 	format \
 	clippy \
 	machete \
@@ -38,6 +39,9 @@ install-llvm-builder:
 install-llvm: install-llvm-builder
 	revive-llvm clone
 	revive-llvm build --llvm-projects lld --llvm-projects clang
+
+install-revive-runner: install-revive-runner
+	cargo install --path crates/runner --no-default-features
 
 format:
 	cargo fmt --all --check

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -10,12 +10,19 @@ description = "Execute revive contracts in a simulated blockchain runtime"
 [package.metadata.cargo-machete]
 ignored = ["codec", "scale-info"]
 
+[[bin]]
+name = "revive-runner"
+path = "src/main.rs"
+
 [features]
 std = ["polkadot-sdk/std"]
 default = ["solidity"]
 solidity = ["revive-solidity", "revive-differential"]
 
 [dependencies]
+env_logger = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true, features = ["serde"] }

--- a/crates/runner/README.md
+++ b/crates/runner/README.md
@@ -1,0 +1,26 @@
+# revive-runner
+
+The revive runner is a helper utility aiding in contract debugging.
+
+Given a PVM contract blob, it will upload, deploy and call that contract using a local, stand-alone un-blockchained pallet revive (which is our execution layer).
+
+This is somewhat similar to the geth `evm` utility binary.
+
+## Installation
+
+The `revive-runner` does not depend on the compiler itself, hence installing this utility does not depend on LLVM, so no LLVM build is required.
+
+Inside the root `revive` repository directory, execute:
+
+```bash
+make install-revive-runner
+```
+
+Which will install the `revive-runner` using `cargo`. 
+
+## Usage
+
+Set the `RUST_LOG` environment varibale to the `trace` level to see the full PolkaVM execution trace. For example:
+
+```bash
+RUST_LOG=trace revive-runner -f mycontract.pvm -c a9059cbb000000000000000000000000f24ff3a9cf04c71dbc94d0b566f7a27b94566cac0000000000000000000000000000000000000000000000000000000000000000

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use revive_runner::{Code, OptionalHex, Specs, SpecsAction::*, TestAddress};
+
+/// Execute revive PolkaVM contracts locally.
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Arguments {
+    /// The hex encoded calldata for the contract call.
+    #[arg(short, long)]
+    calldata: Option<String>,
+
+    /// The hex encoded calldata for the contract deployment.
+    #[arg(short, long)]
+    deploy_calldata: Option<String>,
+
+    /// The hex encoded contract code blob to instantiate and execute.
+    #[arg(short, long)]
+    blob: Option<String>,
+
+    /// The contract code to instantiate and execute.
+    #[arg(short, long)]
+    file: Option<PathBuf>,
+
+    /// The origin account used to initiate the deploy and call transactions.
+    #[arg(short, long)]
+    origin: Option<TestAddress>,
+
+    /// The value the call transaction is endowed with.
+    #[arg(short, long)]
+    value: Option<u128>,
+
+    /// The value the deploy transaction is endowed with.
+    #[arg(long)]
+    deploy_value: Option<u128>,
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let arguments = Arguments::parse();
+
+    let code = match (arguments.blob, arguments.file) {
+        (Some(blob), None) => hex::decode(blob)
+            .map_err(|error| anyhow::anyhow!("expected hex encoded PVM blob: {error}"))?,
+        (None, Some(file)) => std::fs::read(&file).map_err(|error| {
+            anyhow::anyhow!("unable to read PVM file {}: {error}", file.display())
+        })?,
+        _ => anyhow::bail!("should either provide a PVM blob or a PVM file"),
+    };
+    let calldata = match arguments.calldata {
+        Some(calldata) => hex::decode(calldata)
+            .map_err(|error| anyhow::anyhow!("expected hex encoded calldata: {error}"))?,
+        None => vec![],
+    };
+    let deploy_calldata = match arguments.deploy_calldata {
+        Some(calldata) => hex::decode(calldata)
+            .map_err(|error| anyhow::anyhow!("expected hex encoded calldata: {error}"))?,
+        None => vec![],
+    };
+    let origin = arguments.origin.unwrap_or(TestAddress::Alice);
+
+    let actions = vec![
+        Instantiate {
+            origin: origin.clone(),
+            value: arguments.deploy_value.unwrap_or(0),
+            gas_limit: None,
+            storage_deposit_limit: None,
+            code: Code::Bytes(code),
+            data: deploy_calldata,
+            salt: OptionalHex::default(),
+        },
+        Call {
+            origin,
+            dest: TestAddress::Instantiated(0),
+            value: arguments.value.unwrap_or(0),
+            gas_limit: None,
+            storage_deposit_limit: None,
+            data: calldata,
+        },
+    ];
+
+    Specs {
+        actions,
+        differential: false,
+        ..Default::default()
+    }
+    .run();
+
+    Ok(())
+}


### PR DESCRIPTION
I had this in mind for a while but never implemented a standalone binary so far because I always end up writing an integration test anyways.

However, using a standalone version of the pallet based on the revive-runner crate is something people filing in bug reports do anyways, for example:
https://github.com/paritytech/revive/issues/266
https://github.com/paritytech/contract-issues/issues/54

I hope having this maintained in the upstream code base here helps people with desired functionality and also keeping the version up to date. @Subway2023 @sekisamu just hit me up here or open an issue or PR here for any missing features you'd like.