### PR TITLE
revive-runner: install with locked dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ install-llvm: install-llvm-builder
 	revive-llvm build --llvm-projects lld --llvm-projects clang
 
 install-revive-runner:
-	cargo install --path crates/runner --no-default-features
+	cargo install --path crates/runner --no-default-features --locked
 
 format:
 	cargo fmt --all --check
@@ -53,7 +53,7 @@ machete:
 	cargo install cargo-machete
 	cargo machete
 
-test: format clippy machete test-cli test-workspace
+test: format clippy machete test-cli test-workspace install-revive-runner
 
 test-integration: install-bin
 	cargo test --package revive-integration

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -17,11 +17,11 @@ path = "src/main.rs"
 [features]
 std = ["polkadot-sdk/std"]
 default = ["solidity"]
-solidity = ["revive-solidity", "revive-differential"]
+solidity = ["revive-solidity", "revive-differential", "revive-llvm-context"]
 
 [dependencies]
 env_logger = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["help", "std", "derive"] }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -41,4 +41,4 @@ polkadot-sdk.features = [
 
 revive-solidity = { workspace = true, optional = true }
 revive-differential = { workspace = true, optional = true }
-revive-llvm-context = { workspace = true }
+revive-llvm-context = { workspace = true, optional = true }


### PR DESCRIPTION
Make the installation of  `revive-runner` easier:
- Use locked dependencies to avoid issues with downstream crates
- Make the llvm-context crate an optional dependency to the runner
- Add it to the default `test` target ensuring that this actually works