### PR TITLE
allow dynamic configuration of the heap memory

### DIFF
--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,10 +1,10 @@
 {
-  "Baseline": 950,
-  "Computation": 2222,
-  "DivisionArithmetics": 8802,
-  "ERC20": 17602,
-  "Events": 1628,
-  "FibonacciIterative": 1485,
-  "Flipper": 2082,
-  "SHA1": 8230
+  "Baseline": 938,
+  "Computation": 2281,
+  "DivisionArithmetics": 8848,
+  "ERC20": 18307,
+  "Events": 1639,
+  "FibonacciIterative": 1496,
+  "Flipper": 2098,
+  "SHA1": 8242
 }

--- a/crates/llvm-context/src/lib.rs
+++ b/crates/llvm-context/src/lib.rs
@@ -28,6 +28,7 @@ pub use self::polkavm::context::function::runtime::entry::Entry as PolkaVMEntryF
 pub use self::polkavm::context::function::runtime::revive::Exit as PolkaVMExitFunction;
 pub use self::polkavm::context::function::runtime::revive::WordToPointer as PolkaVMWordToPointerFunction;
 pub use self::polkavm::context::function::runtime::runtime_code::RuntimeCode as PolkaVMRuntimeCodeFunction;
+pub use self::polkavm::context::function::runtime::sbrk::Sbrk as PolkaVMSbrkFunction;
 pub use self::polkavm::context::function::runtime::FUNCTION_DEPLOY_CODE as PolkaVMFunctionDeployCode;
 pub use self::polkavm::context::function::runtime::FUNCTION_ENTRY as PolkaVMFunctionEntry;
 pub use self::polkavm::context::function::runtime::FUNCTION_RUNTIME_CODE as PolkaVMFunctionRuntimeCode;

--- a/crates/llvm-context/src/polkavm/const/mod.rs
+++ b/crates/llvm-context/src/polkavm/const/mod.rs
@@ -9,6 +9,12 @@ pub static XLEN: usize = revive_common::BIT_LENGTH_X32;
 /// The calldata size global variable name.
 pub static GLOBAL_CALLDATA_SIZE: &str = "calldatasize";
 
+/// The heap size global variable name.
+pub static GLOBAL_HEAP_SIZE: &str = "__heap_size";
+
+/// The heap memory global variable name.
+pub static GLOBAL_HEAP_MEMORY: &str = "__heap_memory";
+
 /// The spill buffer global variable name.
 pub static GLOBAL_ADDRESS_SPILL_BUFFER: &str = "address_spill_buffer";
 

--- a/crates/llvm-context/src/polkavm/context/function/runtime/entry.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/entry.rs
@@ -31,6 +31,21 @@ impl Entry {
             context.xlen_type().get_undef(),
         );
 
+        context.set_global(
+            crate::polkavm::GLOBAL_HEAP_SIZE,
+            context.xlen_type(),
+            AddressSpace::Stack,
+            context.xlen_type().const_zero(),
+        );
+
+        let heap_memory_type = context.byte_type().array_type(context.heap_size);
+        context.set_global(
+            crate::polkavm::GLOBAL_HEAP_MEMORY,
+            heap_memory_type,
+            AddressSpace::Stack,
+            heap_memory_type.const_zero(),
+        );
+
         let address_type = context.integer_type(revive_common::BIT_LENGTH_ETH_ADDRESS);
         context.set_global(
             crate::polkavm::GLOBAL_ADDRESS_SPILL_BUFFER,

--- a/crates/llvm-context/src/polkavm/context/function/runtime/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/mod.rs
@@ -5,6 +5,7 @@ pub mod deploy_code;
 pub mod entry;
 pub mod revive;
 pub mod runtime_code;
+pub mod sbrk;
 
 /// The main entry function name.
 pub const FUNCTION_ENTRY: &str = "__entry";

--- a/crates/llvm-context/src/polkavm/context/function/runtime/sbrk.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/sbrk.rs
@@ -8,16 +8,20 @@ use crate::polkavm::context::Context;
 use crate::polkavm::Dependency;
 use crate::polkavm::WriteLLVM;
 
-/// Implements the simulated `sbrk` system call, reproducing the EVM heap memory semantics.
+/// Simulates the `sbrk` system call, reproducing the semantics of the EVM heap memory.
 ///
-/// The function accepts two parameters:
+/// Parameters:
 /// - The `offset` into the emulated EVM heap memory.
 /// - The `size` of the allocation emulated EVM heap memory.
 ///
-/// Returns a pointer to the EVM heap memory at given `offset`.
-/// Aligns the size with the EVM word size size.
-/// Traps if the aligned size is greater than the configured EVM heap memory.
-/// Store the new memory size the heap size global value.
+/// Returns:
+/// - A pointer to the EVM heap memory at given `offset`.
+///
+/// Semantics:
+/// - Traps if the offset is out of bounds.
+/// - Aligns the total heap memory size to the EVM word size.
+/// - Traps if the memory size would be greater than the configured EVM heap memory size.
+/// - Maintains the total memory size (`msize`) in global heap size value.
 pub struct Sbrk;
 
 impl<D> RuntimeFunction<D> for Sbrk

--- a/crates/llvm-context/src/polkavm/context/function/runtime/sbrk.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/sbrk.rs
@@ -1,0 +1,132 @@
+//! Emulates the linear EVM heap memory via a simulated `sbrk` system call.
+
+use inkwell::values::BasicValue;
+
+use crate::polkavm::context::attribute::Attribute;
+use crate::polkavm::context::runtime::RuntimeFunction;
+use crate::polkavm::context::Context;
+use crate::polkavm::Dependency;
+use crate::polkavm::WriteLLVM;
+
+/// Implements the simulated `sbrk` system call.
+pub struct Sbrk;
+
+impl<D> RuntimeFunction<D> for Sbrk
+where
+    D: Dependency + Clone,
+{
+    const NAME: &'static str = "__sbrk_internal";
+
+    const ATTRIBUTES: &'static [Attribute] = &[
+        Attribute::NoFree,
+        Attribute::NoRecurse,
+        Attribute::WillReturn,
+    ];
+
+    fn r#type<'ctx>(context: &Context<'ctx, D>) -> inkwell::types::FunctionType<'ctx> {
+        context.llvm().ptr_type(Default::default()).fn_type(
+            &[context.xlen_type().into(), context.xlen_type().into()],
+            false,
+        )
+    }
+
+    fn emit_body<'ctx>(
+        &self,
+        context: &mut Context<'ctx, D>,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
+        let offset = Self::paramater(context, 0).into_int_value();
+        let size = Self::paramater(context, 1).into_int_value();
+
+        let trap_block = context.append_basic_block("trap");
+        let offset_in_bounds_block = context.append_basic_block("offset_in_bounds");
+        let is_offset_out_of_bounds = context.builder().build_int_compare(
+            inkwell::IntPredicate::UGE,
+            offset,
+            context.heap_size(),
+            "offset_out_of_bounds",
+        )?;
+        context.build_conditional_branch(
+            is_offset_out_of_bounds,
+            trap_block,
+            offset_in_bounds_block,
+        )?;
+
+        context.set_basic_block(trap_block);
+        context.build_call(context.intrinsics().trap, &[], "invalid_trap");
+        context.build_unreachable();
+
+        context.set_basic_block(offset_in_bounds_block);
+        let size_mask = context
+            .xlen_type()
+            .const_int(revive_common::BYTE_LENGTH_WORD as u64 - 1, false);
+        let size = context.builder().build_and(
+            context
+                .builder()
+                .build_int_add(size, size_mask, "size_plus_mask")?,
+            context
+                .builder()
+                .build_int_neg(size_mask, "size_mask_negate")?,
+            "size_aligned",
+        )?;
+        let size_in_bounds_block = context.append_basic_block("size_in_bounds");
+        let is_size_out_of_bounds = context.builder().build_int_compare(
+            inkwell::IntPredicate::UGT,
+            size,
+            context.heap_size(),
+            "size_out_of_bounds",
+        )?;
+        context.build_conditional_branch(
+            is_size_out_of_bounds,
+            trap_block,
+            size_in_bounds_block,
+        )?;
+
+        context.set_basic_block(size_in_bounds_block);
+        let return_block = context.append_basic_block("return");
+        let new_size_block = context.append_basic_block("new_size");
+        let is_new_size = context.builder().build_int_compare(
+            inkwell::IntPredicate::UGT,
+            size,
+            context
+                .get_global_value(crate::polkavm::GLOBAL_HEAP_SIZE)?
+                .into_int_value(),
+            "is_new_size",
+        )?;
+        context.build_conditional_branch(is_new_size, new_size_block, return_block)?;
+
+        context.set_basic_block(new_size_block);
+        context.build_store(
+            context.get_global(crate::polkavm::GLOBAL_HEAP_SIZE)?.into(),
+            size,
+        )?;
+        context.build_unconditional_branch(return_block);
+
+        context.set_basic_block(return_block);
+        Ok(Some(
+            context
+                .build_gep(
+                    context
+                        .get_global(crate::polkavm::GLOBAL_HEAP_MEMORY)?
+                        .into(),
+                    &[context.xlen_type().const_zero(), offset],
+                    context.byte_type(),
+                    "allocation_start_pointer",
+                )
+                .value
+                .as_basic_value_enum(),
+        ))
+    }
+}
+
+impl<D> WriteLLVM<D> for Sbrk
+where
+    D: Dependency + Clone,
+{
+    fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
+        <Self as RuntimeFunction<_>>::declare(self, context)
+    }
+
+    fn into_llvm(self, context: &mut Context<D>) -> anyhow::Result<()> {
+        <Self as RuntimeFunction<_>>::emit(&self, context)
+    }
+}

--- a/crates/runtime-api/src/polkavm_imports.c
+++ b/crates/runtime-api/src/polkavm_imports.c
@@ -5,28 +5,6 @@
 
 // Missing builtins
 
-#define EVM_WORD_SIZE 32
-#define ALIGN(size) ((size + EVM_WORD_SIZE - 1) & ~(EVM_WORD_SIZE - 1))
-#define MAX_MEMORY_SIZE (64 * 1024)
-char __memory[MAX_MEMORY_SIZE];
-uint32_t __memory_size = 0;
-
-void * __sbrk_internal(uint32_t offset, uint32_t size) {
-    if (offset >= MAX_MEMORY_SIZE || size > MAX_MEMORY_SIZE) {
-        POLKAVM_TRAP();
-    }
-
-    uint32_t new_size = ALIGN(offset + size);
-    if (new_size > MAX_MEMORY_SIZE) {
-        POLKAVM_TRAP();
-    }
-    if (new_size > __memory_size) {
-        __memory_size = new_size;
-    }
-
-    return (void *)&__memory[offset];
-}
-
 void * memset(void *b, int c, size_t len) {
     uint8_t *dest = b;
     while (len-- > 0) *dest++ = c;

--- a/crates/runtime-api/src/polkavm_imports.c
+++ b/crates/runtime-api/src/polkavm_imports.c
@@ -5,12 +5,6 @@
 
 // Missing builtins
 
-void * memset(void *b, int c, size_t len) {
-    uint8_t *dest = b;
-    while (len-- > 0) *dest++ = c;
-    return b;
-}
-
 void * memcpy(void *dst, const void *_src, size_t len) {
     uint8_t *dest = dst;
     const uint8_t *src = _src;

--- a/crates/runtime-api/src/polkavm_imports.rs
+++ b/crates/runtime-api/src/polkavm_imports.rs
@@ -2,14 +2,6 @@ use inkwell::{context::Context, memory_buffer::MemoryBuffer, module::Module, sup
 
 include!(concat!(env!("OUT_DIR"), "/polkavm_imports.rs"));
 
-/// The emulated EVM heap memory global symbol.
-pub static MEMORY: &str = "__memory";
-
-/// The emulated EVM heap memory size global symbol.
-pub static MEMORY_SIZE: &str = "__memory_size";
-
-pub static SBRK: &str = "__sbrk_internal";
-
 pub static ADDRESS: &str = "address";
 
 pub static BALANCE: &str = "balance";
@@ -78,8 +70,7 @@ pub static WEIGHT_TO_FEE: &str = "weight_to_fee";
 
 /// All imported runtime API symbols.
 /// Useful for configuring common attributes and linkage.
-pub static IMPORTS: [&str; 34] = [
-    SBRK,
+pub static IMPORTS: [&str; 33] = [
     ADDRESS,
     BALANCE,
     BALANCE_OF,

--- a/crates/solidity/src/resolc/arguments.rs
+++ b/crates/solidity/src/resolc/arguments.rs
@@ -167,9 +167,13 @@ pub struct Arguments {
     #[arg(long = "recursive-process-input")]
     pub recursive_process_input: Option<String>,
 
-    #[arg(long = "llvm-arg")]
     /// These are passed to LLVM as the command line to allow manual control.
+    #[arg(long = "llvm-arg")]
     pub llvm_arguments: Vec<String>,
+
+    /// The emulated EVM linear heap memory size in Kb.
+    #[arg(long = "heap-size", default_value = "65536")]
+    pub heap_size: u32,
 }
 
 impl Arguments {

--- a/crates/solidity/src/resolc/arguments.rs
+++ b/crates/solidity/src/resolc/arguments.rs
@@ -170,10 +170,6 @@ pub struct Arguments {
     /// These are passed to LLVM as the command line to allow manual control.
     #[arg(long = "llvm-arg")]
     pub llvm_arguments: Vec<String>,
-
-    /// The emulated EVM linear heap memory size in Kb.
-    #[arg(long = "heap-size", default_value = "65536")]
-    pub heap_size: u32,
 }
 
 impl Arguments {

--- a/crates/solidity/src/yul/parser/statement/object.rs
+++ b/crates/solidity/src/yul/parser/statement/object.rs
@@ -209,6 +209,8 @@ where
         revive_llvm_context::PolkaVMRemainderFunction.declare(context)?;
         revive_llvm_context::PolkaVMSignedRemainderFunction.declare(context)?;
 
+        revive_llvm_context::PolkaVMSbrkFunction.declare(context)?;
+
         let mut entry = revive_llvm_context::PolkaVMEntryFunction::default();
         entry.declare(context)?;
 
@@ -260,6 +262,8 @@ where
         revive_llvm_context::PolkaVMSignedDivisionFunction.into_llvm(context)?;
         revive_llvm_context::PolkaVMRemainderFunction.into_llvm(context)?;
         revive_llvm_context::PolkaVMSignedRemainderFunction.into_llvm(context)?;
+
+        revive_llvm_context::PolkaVMSbrkFunction.into_llvm(context)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR changes the implementation of the emulated EVM heap memory: Instead of linking in a C implementation the code is emitted directly into the contract module. Which allows making it configurable via a compiler parameter (a follow up PR to this).