### PR TITLE
add homebrew taps

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,0 +1,43 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Update Formula
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the release version and SHA256
+          VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')
+          SHA256=$(curl -sL https://github.com/paritytech/revive/archive/refs/tags/v${VERSION}.tar.gz | shasum -a 256 | cut -d' ' -f1)
+          
+          # Update the Formula file
+          sed -i "s/url .*/url \"https:\/\/github.com\/paritytech\/revive\/archive\/refs\/tags\/v${VERSION}.tar.gz\"/" Formula/resolc.rb
+          sed -i "s/sha256 .*/sha256 \"${SHA256}\"/" Formula/resolc.rb
+          
+          # Commit and push changes
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/resolc.rb
+          git commit -m "Update resolc to v${VERSION}"
+          git push 

--- a/Formula/README.md
+++ b/Formula/README.md
@@ -1,0 +1,28 @@
+# Revive Homebrew Tap
+
+This repository contains the Homebrew formula for the Revive Solidity Compiler (resolc).
+
+## Installation
+
+To install resolc using Homebrew:
+
+```bash
+brew tap paritytech/revive
+brew install resolc
+```
+
+## Updating
+
+To update the formula:
+
+1. Create a new release on GitHub
+2. Update the `url` and `sha256` in `Formula/resolc.rb`
+3. Commit and push the changes
+
+## Development
+
+To install the development version:
+
+```bash
+brew install --HEAD resolc
+```

--- a/Formula/resolc.rb
+++ b/Formula/resolc.rb
@@ -1,0 +1,19 @@
+class Resolc < Formula
+  desc "Revive Solidity Compiler"
+  homepage "https://github.com/paritytech/revive"
+  url "https://github.com/paritytech/revive/releases/download/v0.1.0-dev.14/resolc-universal-apple-darwin"
+  sha256 "7d5b3cd4233e60e8bfaade398062f1b609166dcb251424cd9d402e51126d8b4f"
+  license "MIT/Apache-2.0"
+
+  depends_on "rust" => :build
+  depends_on "llvm@18" => :build
+
+  def install
+    system "xattr", "-c", "resolc-universal-apple-darwin"
+    bin.install "resolc-universal-apple-darwin" => "resolc"
+  end
+
+  test do
+    system "#{bin}/resolc", "--version"
+  end
+end 


### PR DESCRIPTION
# Add Homebrew Formula for Revive Solidity Compiler (resolc)

This PR adds a Homebrew Formula for the Revive Solidity Compiler (resolc), making it easily installable on macOS systems.

## Changes

- Added `Formula/resolc.rb` with support for binary installation
- Added GitHub workflow to automatically update the Formula on new releases
- Includes necessary steps to handle unsigned macOS binaries using `xattr -c`

## Installation

Once merged, users can install resolc using:
```bash
brew tap paritytech/revive
brew install resolc
```

## Notes

- The Formula uses the pre-built binary from GitHub releases
- Includes automatic SHA256 verification for security
- The GitHub workflow will automatically update the Formula when new releases are published

## Testing

The Formula has been tested with the latest release (v0.1.0-dev.14) and includes a basic test to verify the installation.