### PR TITLE
llvm-builder: use the ninja generator for building the builtins on windows

### DIFF
--- a/.github/workflows/release-llvm.yml
+++ b/.github/workflows/release-llvm.yml
@@ -87,6 +87,11 @@ jobs:
         run: |
           brew install ninja
 
+      - name: Install Dependencies
+        if: ${{ matrix.host == 'windows' }}
+        run: |
+          choco install ninja
+
       - name: Install LLVM Builder
         run: |
           cargo install --path crates/llvm-builder

--- a/crates/llvm-builder/src/builtins.rs
+++ b/crates/llvm-builder/src/builtins.rs
@@ -117,13 +117,7 @@ pub fn build(
     log::info!("building compiler-rt for rv64emac");
 
     crate::utils::check_presence("cmake")?;
-
-    let generator = if cfg!(target_os = "windows") {
-        "Visual Studio 17 2022"
-    } else {
-        crate::utils::check_presence("ninja")?;
-        "Ninja"
-    };
+    crate::utils::check_presence("ninja")?;
 
     let llvm_module_compiler_rt = crate::LLVMPath::llvm_module_compiler_rt()?;
     let llvm_compiler_rt_build = crate::LLVMPath::llvm_build_compiler_rt()?;
@@ -136,7 +130,7 @@ pub fn build(
                 "-B",
                 llvm_compiler_rt_build.to_string_lossy().as_ref(),
                 "-G",
-                generator,
+                "Ninja",
             ])
             .args(CMAKE_STATIC_ARGS)
             .args(cmake_dynamic_args(build_type, target_env)?)


### PR DESCRIPTION
The builtins build should use the Ninja generator (MSVC does not build a valid archive).

Tested and verified here: https://github.com/paritytech/revive-alex-workflowtest/releases/tag/untagged-f02d0f574bab8404fead

Closes #305 