### PR TITLE
solc-json-interface: make the input `Clone`able

### DIFF
--- a/crates/solc-json-interface/src/standard_json/input/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/mod.rs
@@ -25,7 +25,7 @@ use self::settings::Settings;
 use self::source::Source;
 
 /// The `solc --standard-json` input.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Input {
     /// The input language.

--- a/crates/solc-json-interface/src/standard_json/input/settings/metadata.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/metadata.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::standard_json::input::settings::metadata_hash::MetadataHash;
 
 /// The `solc --standard-json` input settings metadata.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {
     /// The bytecode hash mode.

--- a/crates/solc-json-interface/src/standard_json/input/settings/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/mod.rs
@@ -18,7 +18,7 @@ use self::polkavm::PolkaVM;
 use self::selection::Selection;
 
 /// The `solc --standard-json` input settings.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
     /// The target EVM version.

--- a/crates/solc-json-interface/src/standard_json/input/settings/optimizer/details.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/optimizer/details.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// The `solc --standard-json` input settings optimizer details.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Details {
     /// Whether the pass is enabled.

--- a/crates/solc-json-interface/src/standard_json/input/settings/optimizer/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/optimizer/mod.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use self::details::Details;
 
 /// The `solc --standard-json` input settings optimizer.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Optimizer {
     /// Whether the optimizer is enabled.

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/file/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/file/mod.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use self::flag::Flag as SelectionFlag;
 
 /// The `solc --standard-json` output file selection.
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct File {
     /// The per-file output selections.
     #[serde(rename = "", skip_serializing_if = "Option::is_none")]

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use self::file::File as FileSelection;
 
 /// The `solc --standard-json` output selection.
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 pub struct Selection {
     /// Only the 'all' wildcard is available for robustness reasons.
     #[serde(rename = "*", skip_serializing_if = "Option::is_none")]

--- a/crates/solc-json-interface/src/standard_json/input/source.rs
+++ b/crates/solc-json-interface/src/standard_json/input/source.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// The `solc --standard-json` input source.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Source {
     /// The source code file content.


### PR DESCRIPTION
It helps external consumers working with the `revive-solc-json-interface` crate.