### PR TITLE
make resolc crate publishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This is a development pre-release.
 
 Supported `polkadot-sdk` rev: `2503.0.1`
 
+## v0.2.0
+
+This is a development pre-release.
+
+Supported `polkadot-sdk` rev: `2503.0.1`
+
+### Changed
+
+- Removed the license printer from the `resolc` binary.
+
 ## v0.1.0
 
 This is a development pre-release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8533,7 +8533,7 @@ dependencies = [
 
 [[package]]
 name = "resolc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/paritytech/revive"
 rust-version = "1.85.0"
 
 [workspace.dependencies]
-resolc  = { version = "0.1.0", path = "crates/resolc" }
+resolc  = { path = "crates/resolc" }
 revive-benchmarks = { version = "0.1.0", path = "crates/benchmarks" }
 revive-builtins = { version = "0.1.0", path = "crates/builtins" }
 revive-common = { version = "0.1.0", path = "crates/common" }

--- a/crates/resolc/Cargo.toml
+++ b/crates/resolc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolc"
-version.workspace = true
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/resolc/build.rs
+++ b/crates/resolc/build.rs
@@ -1,7 +1,11 @@
 fn main() {
-    let repo = git2::Repository::open("../..").expect("should be a repository");
-    let head = repo.head().expect("should have head");
-    let commit = head.peel_to_commit().expect("should have commit");
-    let id = &commit.id().to_string()[..7];
-    println!("cargo:rustc-env=GIT_COMMIT_HASH={id}");
+    match git2::Repository::open("../..") {
+        Ok(repo) => {
+            let head = repo.head().expect("should have head");
+            let commit = head.peel_to_commit().expect("should have commit");
+            let id = &commit.id().to_string()[..7];
+            println!("cargo:rustc-env=GIT_COMMIT_HASH={id}");
+        }
+        Err(_) => println!("cargo:rustc-env=GIT_COMMIT_HASH=unknown"),
+    };
 }

--- a/crates/resolc/src/resolc/arguments.rs
+++ b/crates/resolc/src/resolc/arguments.rs
@@ -23,10 +23,6 @@ pub struct Arguments {
     #[arg(long = "supported-solc-versions")]
     pub supported_solc_versions: bool,
 
-    /// Print the licence and exit.
-    #[arg(long = "license")]
-    pub license: bool,
-
     /// Specify the input paths and remappings.
     /// If an argument contains a '=', it is considered a remapping.
     /// Multiple Solidity files can be passed in the default Solidity mode.

--- a/crates/resolc/src/resolc/main.rs
+++ b/crates/resolc/src/resolc/main.rs
@@ -51,14 +51,6 @@ fn main_inner() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    if arguments.license {
-        let license_mit = include_str!("../../../../LICENSE-MIT");
-        let license_apache = include_str!("../../../../LICENSE-APACHE");
-
-        writeln!(std::io::stdout(), "{}\n{}\n", license_mit, license_apache)?;
-        return Ok(());
-    }
-
     #[cfg(feature = "parallel")]
     rayon::ThreadPoolBuilder::new()
         .stack_size(RAYON_WORKER_STACK_SIZE)


### PR DESCRIPTION
- Fetching the commit SHA must not panic if not executed in a git repository.
- Remove the license printer.