### PR TITLE
Fix npm package resolution

### DIFF
--- a/js/resolc/package.json
+++ b/js/resolc/package.json
@@ -32,6 +32,7 @@
         "@types/node": "^22.9.0",
         "commander": "^13.1.0",
         "package-json": "^10.0.1",
+        "resolve-pkg": "^2.0.0",
         "solc": ">=0.8.0 <=0.8.30"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,12 +44,17 @@
     },
     "js/resolc": {
       "name": "@parity/resolc",
+<<<<<<< Updated upstream
       "version": "0.1.0",
+=======
+      "version": "0.1.0-dev.16",
+>>>>>>> Stashed changes
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^22.9.0",
         "commander": "^13.1.0",
         "package-json": "^10.0.1",
+        "resolve-pkg": "^2.0.0",
         "solc": ">=0.8.0 <=0.8.30"
       },
       "bin": {
@@ -5599,6 +5604,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
+      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve.exports": {


### PR DESCRIPTION
Current approach fails with an 'ERR_PACKAGE_PATH_NOT_EXPORTED' error for npm package that defines an exports field in the package.json

e.g:
> require.resolve('@redstone-finance/evm-connector/package.json')
will fail with
Uncaught:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /home/pg/github/evm-test-suite/eth-rpc/node_modules/@redstone-finance/evm-connector/package.json
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
