### PR TITLE
add the missing memset builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Supported `polkadot-sdk` rev: `2503.0.1`
 ### Fixed
 
 - llvm-context: Bugfix the SAR YUL builtin translation.
+- runtime-api: Add the missing `memset` builtin.
 - npm package: Bugfix the exports field defined in the `package.json`.
 
 

--- a/crates/resolc/src/tests/cli-tests/src/contracts/yul/memset.yul
+++ b/crates/resolc/src/tests/cli-tests/src/contracts/yul/memset.yul
@@ -1,0 +1,22 @@
+object "Test" {                                                                                                                                            
+        code {                                                                                                                                                 
+        function allocate(size) -> ptr {                                                                                                                       
+            ptr := mload(0x40)                                                                                                                                 
+            if iszero(ptr) { ptr := 0x60 }                                                                                                                     
+            mstore(0x40, add(ptr, size))                                                                                                                       
+        }                                                                                                                                                      
+        let size := datasize("Test_deployed")          
+        let offset := allocate(size)                                                                                                                           
+        datacopy(offset, dataoffset("Test_deployed"), size)
+        return(offset, size)                                                                                                                                   
+    }                                                                          
+    object "Test_deployed" {                                                                                                                                   
+        code {                                                                                                                                                 
+{                                                                                                                                                              
+        let test:=0x5                                                                                                                                          
+        mstore(2,signextend(0x8,0x0))                                                                                                                          
+        mstore(8,lt(0xc,test))                                                 
+}                                                                                                                                                              
+                                                                                                                                                               
+    return(0, 65536)                                                                                                                                           
+}}}

--- a/crates/resolc/src/tests/cli-tests/src/entities.ts
+++ b/crates/resolc/src/tests/cli-tests/src/entities.ts
@@ -15,6 +15,11 @@ const pathToBasicYulContract = path.join(
   'yul',
   contractYulFilename
 )
+const pathToMemsetYulContract = path.join(
+  pathToContracts,
+  'yul',
+  'memset.yul'
+)
 const pathToBasicSolContract = path.join(
   pathToContracts,
   'solidity',
@@ -42,6 +47,7 @@ export const paths = {
   pathToContracts: pathToContracts,
   pathToBasicSolContract: pathToBasicSolContract,
   pathToBasicYulContract: pathToBasicYulContract,
+  pathToMemsetYulContract: pathToMemsetYulContract,
   pathToSolBinOutputFile: pathToSolBinOutputFile,
   pathToSolAsmOutputFile: pathToSolAsmOutputFile,
 }

--- a/crates/resolc/src/tests/cli-tests/tests/memset.test.ts
+++ b/crates/resolc/src/tests/cli-tests/tests/memset.test.ts
@@ -1,0 +1,18 @@
+import { executeCommand } from '../src/helper'
+import { paths } from '../src/entities'
+
+describe('tests for the memset builtin to be present', () => {
+  // -O3 is required to reproduce.
+  const command = `resolc ${paths.pathToMemsetYulContract} --yul -O3`
+  const result = executeCommand(command)
+
+  it('Valid command exit code = 0', () => {
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('--yul output is presented', () => {
+    expect(result.output).toMatch(/(Compiler run successful)/i)
+    expect(result.output).toMatch(/(No output requested)/i)
+  })
+
+})

--- a/crates/runtime-api/src/polkavm_imports.c
+++ b/crates/runtime-api/src/polkavm_imports.c
@@ -32,7 +32,8 @@ void * memmove(void *dst, const void *src, size_t n) {
 
 void * memset(void *b, int c, size_t len) {
     uint8_t *dest = b;
-    while (len-- > 0) *dest++ = c;
+    uint8_t val = (uint8_t)c;
+    while (len-- > 0) *dest++ = val;
     return b;
 }
 

--- a/crates/runtime-api/src/polkavm_imports.c
+++ b/crates/runtime-api/src/polkavm_imports.c
@@ -30,6 +30,12 @@ void * memmove(void *dst, const void *src, size_t n) {
 	return dst;
 }
 
+void * memset(void *b, int c, size_t len) {
+    uint8_t *dest = b;
+    while (len-- > 0) *dest++ = c;
+    return b;
+}
+
 // Imports
 
 POLKAVM_IMPORT(void, address, uint32_t)


### PR DESCRIPTION
Closes  #350

- Add the missing `memset` builtin which was accidentally deleted in a previous PR.
- Add a compilation test to ensure the `memset` builtin is present.