### PR TITLE
Update workflows to skip tests for only `.md` files

### DIFF
--- a/.github/workflows/test-llvm-builder.yml
+++ b/.github/workflows/test-llvm-builder.yml
@@ -7,6 +7,8 @@ on:
       - 'LLVM.lock'
       - 'crates/llvm-builder/**'
       - '.github/workflows/test-llvm-builder.yml'
+    paths-ignore:
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test-wasm.yml
+++ b/.github/workflows/test-wasm.yml
@@ -2,9 +2,13 @@ name: Test Wasm Version
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches: ["main"]
     types: [opened, synchronize]
+    paths-ignore:
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,13 @@ name: Test
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches: ["main"]
     types: [opened, synchronize]
+    paths-ignore:
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
When updating documentation Markdown files, long-running tests still run unnecessarily. With these changes, it will skip running test workflows when PRs only containing changes to such files are opened.