### PR TITLE
Prevent frontend function confusion

### DIFF
--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,10 +1,10 @@
 {
   "Baseline": 932,
   "Computation": 2313,
-  "DivisionArithmetics": 8959,
-  "ERC20": 16993,
+  "DivisionArithmetics": 9103,
+  "ERC20": 17479,
   "Events": 1692,
-  "FibonacciIterative": 1474,
+  "FibonacciIterative": 1508,
   "Flipper": 2098,
-  "SHA1": 7751
+  "SHA1": 8176
 }

--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,10 +1,10 @@
 {
   "Baseline": 932,
   "Computation": 2313,
-  "DivisionArithmetics": 9103,
-  "ERC20": 17479,
+  "DivisionArithmetics": 8959,
+  "ERC20": 16993,
   "Events": 1692,
-  "FibonacciIterative": 1508,
+  "FibonacciIterative": 1474,
   "Flipper": 2098,
-  "SHA1": 8176
+  "SHA1": 7751
 }

--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,10 +1,10 @@
 {
-  "Baseline": 960,
-  "Computation": 2356,
-  "DivisionArithmetics": 8964,
-  "ERC20": 17143,
-  "Events": 1680,
-  "FibonacciIterative": 1502,
-  "Flipper": 2137,
-  "SHA1": 7740
+  "Baseline": 932,
+  "Computation": 2313,
+  "DivisionArithmetics": 8959,
+  "ERC20": 16993,
+  "Events": 1692,
+  "FibonacciIterative": 1474,
+  "Flipper": 2098,
+  "SHA1": 7751
 }

--- a/crates/llvm-context/src/polkavm/context/function/runtime/deploy_code.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/deploy_code.rs
@@ -1,6 +1,5 @@
 //! The deploy code function.
 
-use crate::polkavm::context::code_type::CodeType;
 use crate::polkavm::context::function::runtime;
 use crate::polkavm::context::Context;
 use crate::polkavm::WriteLLVM;
@@ -38,16 +37,16 @@ where
             0,
             Some(inkwell::module::Linkage::Private),
             None,
+            false,
         )?;
 
         self.inner.declare(context)
     }
 
     fn into_llvm(self, context: &mut Context) -> anyhow::Result<()> {
-        context.set_current_function(runtime::FUNCTION_DEPLOY_CODE, None)?;
+        context.set_current_function(runtime::FUNCTION_DEPLOY_CODE, None, false)?;
 
         context.set_basic_block(context.current_function().borrow().entry_block());
-        context.set_code_type(CodeType::Deploy);
 
         self.inner.into_llvm(context)?;
         context.set_debug_location(0, 0, None)?;

--- a/crates/llvm-context/src/polkavm/context/function/runtime/entry.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/entry.rs
@@ -138,6 +138,7 @@ impl WriteLLVM for Entry {
             0,
             Some(inkwell::module::Linkage::External),
             None,
+            false,
         )?;
 
         context.declare_global(
@@ -160,7 +161,7 @@ impl WriteLLVM for Entry {
     /// The `entry` function loads calldata, sets globals and calls the runtime or deploy code.
     fn into_llvm(self, context: &mut Context) -> anyhow::Result<()> {
         let entry = context
-            .get_function(runtime::FUNCTION_ENTRY)
+            .get_function(runtime::FUNCTION_ENTRY, false)
             .expect("the entry function should already be declared")
             .borrow()
             .declaration;
@@ -171,7 +172,7 @@ impl WriteLLVM for Entry {
             true,
         );
 
-        context.set_current_function(runtime::FUNCTION_ENTRY, None)?;
+        context.set_current_function(runtime::FUNCTION_ENTRY, None, false)?;
         context.set_basic_block(context.current_function().borrow().entry_block());
 
         Self::initialize_globals(context)?;

--- a/crates/llvm-context/src/polkavm/context/function/runtime/runtime_code.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/runtime_code.rs
@@ -1,6 +1,5 @@
 //! The runtime code function.
 
-use crate::polkavm::context::code_type::CodeType;
 use crate::polkavm::context::function::runtime;
 use crate::polkavm::context::Context;
 use crate::polkavm::WriteLLVM;
@@ -38,16 +37,16 @@ where
             0,
             Some(inkwell::module::Linkage::Private),
             None,
+            false,
         )?;
 
         self.inner.declare(context)
     }
 
     fn into_llvm(self, context: &mut Context) -> anyhow::Result<()> {
-        context.set_current_function(runtime::FUNCTION_RUNTIME_CODE, None)?;
+        context.set_current_function(runtime::FUNCTION_RUNTIME_CODE, None, false)?;
 
         context.set_basic_block(context.current_function().borrow().entry_block());
-        context.set_code_type(CodeType::Runtime);
 
         self.inner.into_llvm(context)?;
         context.set_debug_location(0, 0, None)?;

--- a/crates/llvm-context/src/polkavm/context/runtime.rs
+++ b/crates/llvm-context/src/polkavm/context/runtime.rs
@@ -32,6 +32,7 @@ pub trait RuntimeFunction {
             0,
             Some(inkwell::module::Linkage::LinkOnceODR),
             None,
+            false,
         )?;
 
         let mut attributes = Self::ATTRIBUTES.to_vec();
@@ -58,7 +59,7 @@ pub trait RuntimeFunction {
     /// Get the function declaration.
     fn declaration<'ctx>(context: &Context<'ctx>) -> Declaration<'ctx> {
         context
-            .get_function(Self::NAME)
+            .get_function(Self::NAME, false)
             .unwrap_or_else(|| panic!("runtime function {} should be declared", Self::NAME))
             .borrow()
             .declaration()
@@ -66,7 +67,7 @@ pub trait RuntimeFunction {
 
     /// Emit the function.
     fn emit(&self, context: &mut Context) -> anyhow::Result<()> {
-        context.set_current_function(Self::NAME, None)?;
+        context.set_current_function(Self::NAME, None, false)?;
         context.set_basic_block(context.current_function().borrow().entry_block());
 
         let return_value = self.emit_body(context)?;
@@ -105,7 +106,7 @@ pub trait RuntimeFunction {
     ) -> inkwell::values::BasicValueEnum<'ctx> {
         let name = Self::NAME;
         context
-            .get_function(name)
+            .get_function(name, false)
             .unwrap_or_else(|| panic!("runtime function {name} should be declared"))
             .borrow()
             .declaration()

--- a/crates/llvm-context/src/polkavm/context/runtime.rs
+++ b/crates/llvm-context/src/polkavm/context/runtime.rs
@@ -30,7 +30,7 @@ pub trait RuntimeFunction {
             Self::NAME,
             Self::r#type(context),
             0,
-            Some(inkwell::module::Linkage::External), // TODO: `Private` emits unrelocated AUIPC?
+            Some(inkwell::module::Linkage::LinkOnceODR),
             None,
         )?;
 
@@ -45,6 +45,12 @@ pub trait RuntimeFunction {
             &attributes,
             true,
         );
+        let function = function.borrow().declaration().function_value();
+        let comdat = context
+            .module()
+            .get_or_insert_comdat(&format!("{}_comdat", Self::NAME));
+        comdat.set_selection_kind(inkwell::comdat::ComdatSelectionKind::NoDuplicates);
+        function.as_global_value().set_comdat(comdat);
 
         Ok(())
     }

--- a/crates/llvm-context/src/polkavm/context/tests.rs
+++ b/crates/llvm-context/src/polkavm/context/tests.rs
@@ -38,6 +38,7 @@ pub fn check_attribute_null_pointer_is_invalid() {
             1,
             Some(inkwell::module::Linkage::External),
             None,
+            false,
         )
         .expect("Failed to add function");
     assert!(!function
@@ -62,6 +63,7 @@ pub fn check_attribute_optimize_for_size_mode_3() {
             1,
             Some(inkwell::module::Linkage::External),
             None,
+            false,
         )
         .expect("Failed to add function");
     assert!(!function
@@ -86,6 +88,7 @@ pub fn check_attribute_optimize_for_size_mode_z() {
             1,
             Some(inkwell::module::Linkage::External),
             None,
+            false,
         )
         .expect("Failed to add function");
     assert!(function
@@ -110,6 +113,7 @@ pub fn check_attribute_min_size_mode_3() {
             1,
             Some(inkwell::module::Linkage::External),
             None,
+            false,
         )
         .expect("Failed to add function");
     assert!(!function
@@ -134,6 +138,7 @@ pub fn check_attribute_min_size_mode_z() {
             1,
             Some(inkwell::module::Linkage::External),
             None,
+            false,
         )
         .expect("Failed to add function");
     assert!(function

--- a/crates/llvm-context/src/polkavm/evm/immutable.rs
+++ b/crates/llvm-context/src/polkavm/evm/immutable.rs
@@ -210,7 +210,7 @@ pub fn load<'ctx>(
             let name = <Load as RuntimeFunction>::NAME;
             context.build_call(
                 context
-                    .get_function(name)
+                    .get_function(name, false)
                     .expect("is always declared for runtime code")
                     .borrow()
                     .declaration(),

--- a/crates/yul/src/parser/statement/block.rs
+++ b/crates/yul/src/parser/statement/block.rs
@@ -159,6 +159,7 @@ impl PolkaVMWriteLLVM for Block {
         context.set_current_function(
             current_function.as_str(),
             Some((self.location.line, self.location.column)),
+            false,
         )?;
 
         if let Some(debug_info) = context.debug_info() {

--- a/crates/yul/src/parser/statement/expression/function_call/mod.rs
+++ b/crates/yul/src/parser/statement/expression/function_call/mod.rs
@@ -135,7 +135,7 @@ impl FunctionCall {
                     values.push(value);
                 }
                 values.reverse();
-                let function = context.get_function(name.as_str()).ok_or_else(|| {
+                let function = context.get_function(name.as_str(), true).ok_or_else(|| {
                     anyhow::anyhow!("{} Undeclared function `{}`", location, name)
                 })?;
 

--- a/crates/yul/src/parser/statement/function_definition.rs
+++ b/crates/yul/src/parser/statement/function_definition.rs
@@ -217,6 +217,7 @@ impl PolkaVMWriteLLVM for FunctionDefinition {
             self.result.len(),
             Some(inkwell::module::Linkage::External),
             Some((self.location.line, self.location.column)),
+            true,
         )?;
         PolkaVMFunction::set_attributes(
             context.llvm(),
@@ -235,6 +236,7 @@ impl PolkaVMWriteLLVM for FunctionDefinition {
         context.set_current_function(
             self.identifier.as_str(),
             Some((self.location.line, self.location.column)),
+            true,
         )?;
         context.set_basic_block(context.current_function().borrow().entry_block());
 

--- a/crates/yul/src/parser/statement/function_definition.rs
+++ b/crates/yul/src/parser/statement/function_definition.rs
@@ -215,7 +215,7 @@ impl PolkaVMWriteLLVM for FunctionDefinition {
             self.identifier.as_str(),
             function_type,
             self.result.len(),
-            Some(inkwell::module::Linkage::Private),
+            Some(inkwell::module::Linkage::External),
             Some((self.location.line, self.location.column)),
         )?;
         PolkaVMFunction::set_attributes(


### PR DESCRIPTION
Function symbols can clash as we compile multiple YUL `object` definition (different scopes) into the same `LLVM` module (same scope).
- Disambiguate via unique function symbols based its location, i.e. runtime or deploy code.
- Use `LinkOnceODR` linkage for compiler builtin helpers.