### PR TITLE
do not prune the AST output in standard JSON mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This is a development pre-release.
 
 Supported `polkadot-sdk` rev: `2503.0.1`
 
+### Changed
+- The `ast` output is no longer pruned in standard JSON mode (required for foundry).
+
 ## v0.4.0
 
 This is a development pre-release.

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/file/flag.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/file/flag.rs
@@ -47,24 +47,3 @@ pub enum Flag {
     #[serde(rename = "ir")]
     Ir,
 }
-
-//impl std::fmt::Display for Flag {
-//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//        match self {
-//            Self::ABI => write!(f, "abi"),
-//            Self::Metadata => write!(f, "metadata"),
-//            Self::Devdoc => write!(f, "devdoc"),
-//            Self::Userdoc => write!(f, "userdoc"),
-//            Self::MethodIdentifiers => write!(f, "evm.methodIdentifiers"),
-//            Self::StorageLayout => write!(f, "storageLayout"),
-//            Self::AST => write!(f, "ast"),
-//            Self::Yul => write!(f, "irOptimized"),
-//            Self::EVM => write!(f, "evm"),
-//            Self::EVMLA => write!(f, "evm.legacyAssembly"),
-//            Self::EVMBC => write!(f, "evm.bytecode"),
-//            Self::EVMDBC => write!(f, "evm.deployedBytecode"),
-//            Self::Assembly => write!(f, "evm.assembly"),
-//            Self::Ir => write!(f, "ir"),
-//        }
-//    }
-//}

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/file/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/file/mod.rs
@@ -40,17 +40,6 @@ impl File {
             per_contract,
         }
     }
-    /// Creates the selection required for production compilation (excludes EVM bytecode).
-    pub fn new_required() -> Self {
-        Self {
-            per_file: HashSet::from_iter([SelectionFlag::AST]),
-            per_contract: HashSet::from_iter([
-                SelectionFlag::MethodIdentifiers,
-                SelectionFlag::Metadata,
-                SelectionFlag::Yul,
-            ]),
-        }
-    }
 
     /// Creates the selection required for test compilation (includes EVM bytecode).
     pub fn new_required_for_tests() -> Self {
@@ -64,16 +53,6 @@ impl File {
                 SelectionFlag::Yul,
             ]),
         }
-    }
-
-    /// Extends the user's output selection with flag required by our compilation process.
-    pub fn extend_with_required(&mut self) -> &mut Self {
-        let required = Self::new_required();
-
-        self.per_file.extend(required.per_file);
-        self.per_contract.extend(required.per_contract);
-
-        self
     }
 
     /// Extends the output selection with another one.

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -2,8 +2,6 @@
 
 pub mod file;
 
-use std::collections::BTreeMap;
-
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -15,10 +13,7 @@ use self::file::File as FileSelection;
 pub struct Selection {
     /// Only the 'all' wildcard is available for robustness reasons.
     #[serde(default, rename = "*", skip_serializing_if = "FileSelection::is_empty")]
-    all: FileSelection,
-
-    #[serde(skip_serializing_if = "BTreeMap::is_empty", flatten)]
-    pub files: BTreeMap<String, FileSelection>,
+    pub all: FileSelection,
 }
 
 impl Selection {
@@ -26,23 +21,23 @@ impl Selection {
     pub fn new(flags: Vec<Flag>) -> Self {
         Self {
             all: FileSelection::new(flags),
-            files: Default::default(),
         }
     }
 
     /// Creates the selection required by our compilation process.
     pub fn new_required() -> Self {
-        Self {
-            all: FileSelection::new_required(),
-            files: BTreeMap::new(),
-        }
+        Self::new(vec![
+            Flag::AST,
+            Flag::MethodIdentifiers,
+            Flag::Metadata,
+            Flag::Yul,
+        ])
     }
 
     /// Creates the selection required for test compilation (includes EVM bytecode).
     pub fn new_required_for_tests() -> Self {
         Self {
             all: FileSelection::new_required_for_tests(),
-            files: BTreeMap::new(),
         }
     }
 
@@ -64,7 +59,6 @@ impl Selection {
     pub fn selection_to_prune(&self) -> Self {
         Self {
             all: self.all.selection_to_prune(),
-            files: Default::default(),
         }
     }
 

--- a/crates/solc-json-interface/src/standard_json/output/contract/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/output/contract/mod.rs
@@ -2,7 +2,9 @@
 
 pub mod evm;
 
+#[cfg(feature = "resolc")]
 use std::collections::BTreeMap;
+#[cfg(feature = "resolc")]
 use std::collections::BTreeSet;
 
 use serde::Deserialize;
@@ -45,19 +47,24 @@ pub struct Contract {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
     /// Unlinked factory dependencies.
+    #[cfg(feature = "resolc")]
     #[serde(default, skip_deserializing)]
     pub factory_dependencies_unlinked: BTreeSet<String>,
     /// The contract factory dependencies.
+    #[cfg(feature = "resolc")]
     #[serde(default, skip_deserializing)]
     pub factory_dependencies: BTreeMap<String, String>,
     /// Missing linkable libraries.
+    #[cfg(feature = "resolc")]
     #[serde(default, skip_deserializing)]
     pub missing_libraries: BTreeSet<String>,
     /// Binary object format.
-    #[serde(default, skip_deserializing)]
+    #[cfg(feature = "resolc")]
+    #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
     pub object_format: Option<revive_common::ObjectFormat>,
 }
 
+#[cfg(feature = "resolc")]
 impl Contract {
     /// Checks if all fields are unset or empty.
     pub fn is_empty(&self) -> bool {

--- a/crates/solc-json-interface/src/standard_json/output/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/output/mod.rs
@@ -12,7 +12,7 @@ use crate::standard_json::output::error::error_handler::ErrorHandler;
 use crate::SolcStandardJsonInputSettingsSelection;
 #[cfg(feature = "resolc")]
 use crate::SolcStandardJsonInputSource;
-#[cfg(feature = "parallel")]
+#[cfg(all(feature = "parallel", feature = "resolc"))]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use self::contract::Contract;
@@ -92,15 +92,6 @@ impl Output {
         mut self,
         selection_to_prune: SolcStandardJsonInputSettingsSelection,
     ) -> ! {
-        let sources = self.sources.values_mut().collect::<Vec<&mut Source>>();
-        for source in sources.into_iter() {
-            if selection_to_prune
-                .contains(&crate::SolcStandardJsonInputSettingsSelectionFileFlag::AST)
-            {
-                source.ast = None;
-            }
-        }
-
         let contracts = self
             .contracts
             .values_mut()


### PR DESCRIPTION
- do not prune the AST output in standard JSON mode (required for foundry)
- do not serialize the output format if there was not blob produced