### PR TITLE
Fix output selection issues for `Foundry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed 
+- revert `standard_json.output.source.ast` change to include the `ast`.
+- `standard_json.output_selection` to also look at per file settings.
+
 This is a development pre-release.
 
 Supported `polkadot-sdk` rev: `2503.0.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Unreleased
 
 ### Changed 
-- revert `standard_json.output.source.ast` change to include the `ast`.
-- Restore `standard_json.output_selection` to also look at per file settings.
+- `standard_json.output_selection` to also look at per file settings.
 
 This is a development pre-release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed 
 - revert `standard_json.output.source.ast` change to include the `ast`.
-- `standard_json.output_selection` to also look at per file settings.
+- Restore `standard_json.output_selection` to also look at per file settings.
 
 This is a development pre-release.
 

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -78,7 +78,7 @@ impl Selection {
 
         Self {
             all: self.all.selection_to_prune(),
-            files: files,
+            files,
         }
     }
 

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -9,14 +9,54 @@ use std::collections::BTreeMap;
 use self::file::flag::Flag;
 use self::file::File as FileSelection;
 
+/// The `solc --standard-json` per-file output selection.
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+struct PerFileSelection {
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", flatten)]
+    pub files: BTreeMap<String, FileSelection>,
+}
+
+impl PerFileSelection {
+    fn extend(&mut self, other: Self) {
+        for (entry, file) in other.files {
+            self.files
+                .entry(entry)
+                .and_modify(|v| {
+                    v.extend(file.clone());
+                })
+                .or_insert(file);
+        }
+    }
+
+    fn selection_to_prune(&self) -> Self {
+        let files = self
+            .files
+            .iter()
+            .map(|(k, v)| (k.to_owned(), v.selection_to_prune()))
+            .collect();
+        Self { files }
+    }
+
+    fn contains(&self, path: &String, flag: &Flag) -> Option<bool> {
+        if let Some(file) = self.files.get(path) {
+            return Some(file.contains(flag));
+        };
+        None
+    }
+
+    fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+}
+
 /// The `solc --standard-json` output selection.
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 pub struct Selection {
     /// Only the 'all' wildcard is available for robustness reasons.
     #[serde(default, rename = "*", skip_serializing_if = "FileSelection::is_empty")]
     pub all: FileSelection,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty", flatten)]
-    pub files: BTreeMap<String, FileSelection>,
+    #[serde(skip_serializing_if = "PerFileSelection::is_empty", flatten)]
+    files: PerFileSelection,
 }
 
 impl Selection {
@@ -54,14 +94,7 @@ impl Selection {
     /// Extends the output selection with another one.
     pub fn extend(&mut self, other: Self) -> &mut Self {
         self.all.extend(other.all);
-        for (entry, file) in other.files {
-            self.files
-                .entry(entry)
-                .and_modify(|v| {
-                    v.extend(file.clone());
-                })
-                .or_insert(file);
-        }
+        self.files.extend(other.files);
         self
     }
 
@@ -70,23 +103,16 @@ impl Selection {
     ///
     /// Afterwards, the flags are used to prune JSON output before returning it.
     pub fn selection_to_prune(&self) -> Self {
-        let files = self
-            .files
-            .iter()
-            .map(|(k, v)| (k.to_owned(), v.selection_to_prune()))
-            .collect();
-
         Self {
             all: self.all.selection_to_prune(),
-            files,
+            files: self.files.selection_to_prune(),
         }
     }
 
     /// Whether the flag is requested.
     pub fn contains(&self, path: &String, flag: &Flag) -> bool {
-        if let Some(file) = self.files.get(path) {
-            return file.contains(flag);
-        };
-        self.all.contains(flag)
+        self.files
+            .contains(path, flag)
+            .unwrap_or(self.all.contains(flag))
     }
 }

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -12,12 +12,14 @@ use self::file::File as FileSelection;
 /// The `solc --standard-json` per-file output selection.
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 struct PerFileSelection {
+    /// Individual file selection configuration, required for foundry.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", flatten)]
     pub files: BTreeMap<String, FileSelection>,
 }
 
 impl PerFileSelection {
-    fn extend(&mut self, other: Self) {
+    /// Extends the output selection with another one.
+    pub fn extend(&mut self, other: Self) {
         for (entry, file) in other.files {
             self.files
                 .entry(entry)
@@ -28,7 +30,11 @@ impl PerFileSelection {
         }
     }
 
-    fn selection_to_prune(&self) -> Self {
+    /// Returns flags that are going to be automatically added by the compiler,
+    /// but were not explicitly requested by the user.
+    ///
+    /// Afterwards, the flags are used to prune JSON output before returning it.
+    pub fn selection_to_prune(&self) -> Self {
         let files = self
             .files
             .iter()
@@ -37,14 +43,16 @@ impl PerFileSelection {
         Self { files }
     }
 
-    fn contains(&self, path: &String, flag: &Flag) -> Option<bool> {
+    /// Returns whether `path` contains the `flag` or `None` if there is no selection for `path`.
+    pub fn contains(&self, path: &String, flag: &Flag) -> Option<bool> {
         if let Some(file) = self.files.get(path) {
             return Some(file.contains(flag));
         };
         None
     }
 
-    fn is_empty(&self) -> bool {
+    /// Returns whether this is the empty per file selection.
+    pub fn is_empty(&self) -> bool {
         self.files.is_empty()
     }
 }
@@ -54,6 +62,7 @@ impl PerFileSelection {
 pub struct Selection {
     /// Only the 'all' wildcard is available for robustness reasons.
     #[serde(default, rename = "*", skip_serializing_if = "FileSelection::is_empty")]
+    /// Individual file selection configuration, required for foundry.
     pub all: FileSelection,
     #[serde(skip_serializing_if = "PerFileSelection::is_empty", flatten)]
     files: PerFileSelection,
@@ -79,6 +88,7 @@ impl Selection {
     }
 
     /// Creates the selection required for test compilation (includes EVM bytecode).
+    /// Returns the file selection required during tests.
     pub fn new_required_for_tests() -> Self {
         Self {
             all: FileSelection::new_required_for_tests(),

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -12,7 +12,7 @@ use self::file::File as FileSelection;
 
 /// The `solc --standard-json` per-file output selection.
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
-struct PerFileSelection {
+pub struct PerFileSelection {
     /// Individual file selection configuration, required for foundry.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", flatten)]
     pub files: BTreeMap<String, FileSelection>,

--- a/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/selection/mod.rs
@@ -2,9 +2,10 @@
 
 pub mod file;
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::BTreeMap;
 
 use self::file::flag::Flag;
 use self::file::File as FileSelection;
@@ -88,7 +89,6 @@ impl Selection {
     }
 
     /// Creates the selection required for test compilation (includes EVM bytecode).
-    /// Returns the file selection required during tests.
     pub fn new_required_for_tests() -> Self {
         Self {
             all: FileSelection::new_required_for_tests(),

--- a/crates/solc-json-interface/src/standard_json/output/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/output/mod.rs
@@ -56,14 +56,22 @@ impl Output {
         messages: &mut Vec<SolcStandardJsonOutputError>,
     ) -> Self {
         let sources = sources
-            .keys()
+            .iter()
             .enumerate()
-            .map(|(index, path)| (path.to_owned(), Source::new(index)))
+            .map(|(index, (path, source))| {
+                (
+                    path.to_owned(),
+                    Source {
+                        id: index,
+                        ast: source.content().map(|x| serde_json::to_value(x).unwrap()),
+                    },
+                )
+            })
             .collect::<BTreeMap<String, Source>>();
 
         Self {
             contracts: BTreeMap::new(),
-            sources,
+            sources: sources.clone(),
             errors: std::mem::take(messages),
 
             version: None,
@@ -92,36 +100,27 @@ impl Output {
         mut self,
         selection_to_prune: SolcStandardJsonInputSettingsSelection,
     ) -> ! {
-        let sources = self.sources.values_mut().collect::<Vec<&mut Source>>();
-        for source in sources.into_iter() {
-            if selection_to_prune
-                .contains(&crate::SolcStandardJsonInputSettingsSelectionFileFlag::AST)
-            {
-                source.ast = None;
-            }
-        }
-
-        let contracts = self
-            .contracts
-            .values_mut()
-            .flat_map(|contracts| contracts.values_mut())
-            .collect::<Vec<&mut Contract>>();
-        for contract in contracts.into_iter() {
-            if selection_to_prune
-                .contains(&crate::SolcStandardJsonInputSettingsSelectionFileFlag::Metadata)
-            {
-                contract.metadata = serde_json::Value::Null;
-            }
-            if selection_to_prune
-                .contains(&crate::SolcStandardJsonInputSettingsSelectionFileFlag::Yul)
-            {
-                contract.ir_optimized = String::new();
-            }
-            if let Some(ref mut evm) = contract.evm {
+        for (path, contracts) in self.contracts.iter_mut() {
+            for (_, contract) in contracts {
                 if selection_to_prune.contains(
-                    &crate::SolcStandardJsonInputSettingsSelectionFileFlag::MethodIdentifiers,
+                    path,
+                    &crate::SolcStandardJsonInputSettingsSelectionFileFlag::Metadata,
                 ) {
-                    evm.method_identifiers.clear();
+                    contract.metadata = serde_json::Value::Null;
+                }
+                if selection_to_prune.contains(
+                    path,
+                    &crate::SolcStandardJsonInputSettingsSelectionFileFlag::Yul,
+                ) {
+                    contract.ir_optimized = String::new();
+                }
+                if let Some(ref mut evm) = contract.evm {
+                    if selection_to_prune.contains(
+                        path,
+                        &crate::SolcStandardJsonInputSettingsSelectionFileFlag::MethodIdentifiers,
+                    ) {
+                        evm.method_identifiers.clear();
+                    }
                 }
             }
         }

--- a/crates/solc-json-interface/src/standard_json/output/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/output/mod.rs
@@ -101,7 +101,7 @@ impl Output {
         selection_to_prune: SolcStandardJsonInputSettingsSelection,
     ) -> ! {
         for (path, contracts) in self.contracts.iter_mut() {
-            for (_, contract) in contracts {
+            for contract in contracts.values_mut() {
                 if selection_to_prune.contains(
                     path,
                     &crate::SolcStandardJsonInputSettingsSelectionFileFlag::Metadata,


### PR DESCRIPTION
### Description 

Fixes output selection issues for `Foundry` usage. 

- pruning to look at per file settings
- source to include `ast`


### Note 

`Selection.files` field is reintroduced because that's the way `foundry` functions. it uses per-file output selection