### PR TITLE
llvm-context: fix off-by-one in SDIV overflow semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ This is a development pre-release.
 
 Supported `polkadot-sdk` rev: `2509.0.0`
 
-### Chnaged
+### Changed
 - Emulated EVM heap memory accesses of zero length are never out of bounds.
+
+### Fixed
+- An off-by-one bug cusing incorrect `SDIV` overflow semantics.
 
 ## v0.4.1
 

--- a/crates/integration/codesize.json
+++ b/crates/integration/codesize.json
@@ -1,7 +1,7 @@
 {
   "Baseline": 914,
   "Computation": 2295,
-  "DivisionArithmetics": 14510,
+  "DivisionArithmetics": 14496,
   "ERC20": 17482,
   "Events": 1674,
   "FibonacciIterative": 1490,

--- a/crates/integration/src/tests.rs
+++ b/crates/integration/src/tests.rs
@@ -169,6 +169,8 @@ fn signed_division() {
         (minus_five, two),
         (I256::MINUS_ONE, I256::MIN),
         (one, I256::ZERO),
+        (I256::MIN, I256::MINUS_ONE),
+        (I256::MIN + I256::ONE, I256::MINUS_ONE),
     ] {
         actions.push(Call {
             origin: TestAddress::Alice,

--- a/crates/llvm-context/src/polkavm/context/function/runtime/arithmetics.rs
+++ b/crates/llvm-context/src/polkavm/context/function/runtime/arithmetics.rs
@@ -92,7 +92,7 @@ impl RuntimeFunction for SignedDivision {
             "max_uint",
         )?;
         let is_operand_1_overflow = context.builder().build_int_compare(
-            inkwell::IntPredicate::EQ,
+            inkwell::IntPredicate::SLT,
             operand_1,
             context.builder().build_int_neg(max_uint, "min_uint")?,
             "is_operand_1_overflow",


### PR DESCRIPTION
- Fix the wrong predicate (the negative side in 2s complement has one more bit)
- Increase test coverage