### PR TITLE
Add the LLVM dir to the `.ignore` file

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+# This is no longer in .gitignore; we add it here (honored by tools like rg and fd).
+llvm/


### PR DESCRIPTION
LLVM is now a submodule and no longer in `.gitignore`. Thus, some dev tools I use, like `rg` and `fd`, now consider the `llvm/` directory. This PR fixes that by adding `llvm/` to the `.ignore` file.