### PR TITLE
Update the Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7729,6 +7729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "picosimd"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af35c838647fef3d6d052e27006ef88ea162336eee33063c50a63f163c18cdeb"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8264,15 +8270,16 @@ dependencies = [
 
 [[package]]
 name = "polkavm"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c8211d36125b6cc451b3cbc46b8ee27fefb54521b67f43c8630bd1afbd44d4"
+checksum = "4323d016144b2852da47cee55ca5fc33dfe7517be1f52395759f247ecc5695f6"
 dependencies = [
  "libc",
  "log",
- "polkavm-assembler 0.29.0",
- "polkavm-common 0.29.0",
- "polkavm-linux-raw 0.29.0",
+ "picosimd",
+ "polkavm-assembler 0.30.0",
+ "polkavm-common 0.30.0",
+ "polkavm-linux-raw 0.30.0",
 ]
 
 [[package]]
@@ -8295,9 +8302,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914aacebfbc22da7772f5ecb6f79b39901dc4061121598bd4383a590a7506ebb"
+checksum = "b3a873fa7ace058d6507debf5fccb1d06bd3279f5b35dbaf70dc7fe94a6c415c"
 dependencies = [
  "log",
 ]
@@ -8325,12 +8332,13 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f634b46a6a47a5de381f56d1d8cced9f8640d063b2b1a44b0da6dbef91bbd400"
+checksum = "ed1b408db93d4f49f5c651a7844682b9d7a561827b4dc6202c10356076c055c9"
 dependencies = [
  "log",
- "polkavm-assembler 0.29.0",
+ "picosimd",
+ "polkavm-assembler 0.30.0",
 ]
 
 [[package]]
@@ -8397,15 +8405,15 @@ dependencies = [
 
 [[package]]
 name = "polkavm-disassembler"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467b4ffaae3d2ffdab156aef36b73d70157b0e1d928f26c917b0493845a716a4"
+checksum = "8967ce3348d63ed1d56fa34602182e858b2586da5dfc2866d1b656b104374d65"
 dependencies = [
  "clap",
  "iced-x86",
- "polkavm 0.29.1",
- "polkavm-common 0.29.0",
- "polkavm-linker 0.29.0",
+ "polkavm 0.30.0",
+ "polkavm-common 0.30.0",
+ "polkavm-linker 0.30.0",
 ]
 
 [[package]]
@@ -8426,16 +8434,16 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linker"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e01613e9e3e4ebd624aa3a11f1775a5c90b881200c50e054fe13c3ba451f98"
+checksum = "6739125c4f8f44b4282b6531d765d599f20514e9b608737c6c3544594d08f995"
 dependencies = [
  "dirs",
  "gimli 0.31.1",
  "hashbrown 0.14.5",
  "log",
  "object 0.36.7",
- "polkavm-common 0.29.0",
+ "polkavm-common 0.30.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
@@ -8454,9 +8462,9 @@ checksum = "061088785efd93e4367faf12f341bb356208c06bab43aa942d472068af80d1c4"
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751fbbcf86635834dd9a700039c74ce8c7871b317acc84582d9667dad2ed9848"
+checksum = "604b23cdb201979304449f53d21bfd5fb1724c03e3ea889067c9a3bf7ae33862"
 
 [[package]]
 name = "poly1305"
@@ -9100,7 +9108,7 @@ dependencies = [
  "anyhow",
  "libc",
  "lld-sys",
- "polkavm-linker 0.29.0",
+ "polkavm-linker 0.30.0",
  "revive-builtins",
  "tempfile",
 ]
@@ -9135,7 +9143,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "num",
- "polkavm-common 0.29.0",
+ "polkavm-common 0.30.0",
  "polkavm-disassembler",
  "revive-common",
  "revive-linker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,13 @@ revive-yul = { version = "0.4.0", path = "crates/yul" }
 hex = "0.4.3"
 cc = "1.2"
 libc = "0.2.172"
-tempfile = "3.20"
+tempfile = "3.23"
 anyhow = "1.0"
 semver = { version = "1.0", features = ["serde"] }
 itertools = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
-regex = "1.11"
+regex = "1.12"
 once_cell = "1.21"
 num = "0.4.3"
 sha1 = "0.10"
@@ -48,20 +48,20 @@ sha3 = "0.10"
 thiserror = "2.0"
 which = "8.0"
 path-slash = "0.2"
-rayon = "1.10"
+rayon = "1.11"
 clap = { version = "4", default-features = false, features = ["derive"] }
-polkavm-common = "0.29.0"
-polkavm-linker = "0.29.0"
-polkavm-disassembler = "0.29.0"
-polkavm = "0.29.0"
-alloy-primitives = { version = "1.1", features = ["serde"] }
-alloy-sol-types = "1.1"
-alloy-genesis = "1.0.41"
-alloy-serde = "1.0"
+polkavm-common = "0.30.0"
+polkavm-linker = "0.30.0"
+polkavm-disassembler = "0.30.0"
+polkavm = "0.30.0"
+alloy-primitives = { version = "1.4", features = ["serde"] }
+alloy-sol-types = "1.4"
+alloy-genesis = "1.1.2"
+alloy-serde = "1.1"
 env_logger = { version = "0.11.8", default-features = false }
-serde_stacker = "0.1.12"
+serde_stacker = "0.1.14"
 criterion = { version = "0.7", features = ["html_reports"] }
-log = { version = "0.4.27" }
+log = { version = "0.4.28" }
 git2 = { version = "0.20.2", default-features = false }
 downloader = "0.2.8"
 flate2 = "1.1"
@@ -71,7 +71,7 @@ tar = "0.4"
 toml = "0.9"
 assert_cmd = "2"
 assert_fs = "1.1"
-normpath = "1.3"
+normpath = "1.5"
 
 # polkadot-sdk and friends
 codec = { version = "3.7.5", default-features = false, package = "parity-scale-codec" }

--- a/crates/linker/src/pvm.rs
+++ b/crates/linker/src/pvm.rs
@@ -5,6 +5,10 @@ pub fn polkavm_linker<T: AsRef<[u8]>>(code: T, strip_binary: bool) -> anyhow::Re
     config.set_strip(strip_binary);
     config.set_optimize(true);
 
-    polkavm_linker::program_from_elf(config, code.as_ref())
-        .map_err(|reason| anyhow::anyhow!("polkavm linker failed: {}", reason))
+    polkavm_linker::program_from_elf(
+        config,
+        polkavm_linker::TargetInstructionSet::ReviveV1,
+        code.as_ref(),
+    )
+    .map_err(|reason| anyhow::anyhow!("polkavm linker failed: {}", reason))
 }


### PR DESCRIPTION
The `Cargo.lock` kept changing locally on all my hosts. Not sure why exactly - maybe it got forgotten in a recent PR. I took it as an opportunity to quickly update the Rust dependencies.