### PR TITLE
Clone emsdk for release-llvm CI action

### DIFF
--- a/.github/workflows/release-llvm.yml
+++ b/.github/workflows/release-llvm.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Build LLVM
         if: ${{ matrix.target == 'wasm32-unknown-emscripten' }}
         run: |
-          revive-llvm emsdk clone
+          revive-llvm emsdk
           source emsdk/emsdk_env.sh
           revive-llvm --target-env ${{ matrix.builder-arg }} build --llvm-projects lld
 


### PR DESCRIPTION
Cloning of emsdk has been accidentally removed, that caused inability to
build LLVM release with current main.
The change adds this cloning back before emsdk script is sourced.