### PR TITLE
npm package: fix `--bin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 This is a development pre-release.
 
+### Fixed
+
+- npm package: The `--bin` CLI flag was not producing bytecode because the `outputSelection` was not updated to explicitly requested it.
+
 ## v1.0.0
 
 Supported `polkadot-sdk` rev: `unstable2507`

--- a/js/resolc/src/index.ts
+++ b/js/resolc/src/index.ts
@@ -111,7 +111,7 @@ export async function compile(
       optimizer,
       outputSelection: {
         '*': {
-          '*': ['abi'],
+          '*': ['abi', 'evm.bytecode'],
         },
       },
     },


### PR DESCRIPTION
The `--bin` CLI flag was not producing bytecode because the `outputSelection` was not updated to explicitly requested it.