### PR TITLE
Append `optnone` and `noinline` for -O0 optlevel

### DIFF
--- a/crates/llvm-context/src/polkavm/context/function/mod.rs
+++ b/crates/llvm-context/src/polkavm/context/function/mod.rs
@@ -111,6 +111,10 @@ impl<'ctx> Function<'ctx> {
                         inkwell::attributes::AttributeLoc::Function,
                         Attribute::NoInline as u32,
                     );
+                    declaration.value.remove_enum_attribute(
+                        inkwell::attributes::AttributeLoc::Function,
+                        Attribute::OptimizeNone as u32,
+                    );
                     declaration.value.add_attribute(
                         inkwell::attributes::AttributeLoc::Function,
                         llvm.create_enum_attribute(*attribute_kind as u32, 0),
@@ -165,6 +169,15 @@ impl<'ctx> Function<'ctx> {
                 declaration,
                 &[Attribute::OptimizeForSize, Attribute::MinSize],
                 false,
+            );
+        }
+
+        if !optimizer.settings().is_middle_end_enabled() {
+            Self::set_attributes(
+                llvm,
+                declaration,
+                &[Attribute::NoInline, Attribute::OptimizeNone],
+                true,
             );
         }
 


### PR DESCRIPTION
This appears to be NFC change as new pass manager handles --passes=default<O0> correctly. Still must be useful as a safeguard and possibly for the old pass manager that is still used by backend.

```
Contract                        Without (bytes)   With noinline+optnone (bytes)
─────────────────────────────── ───────────────── ────────────────────────────
contract.sol:C                            1,266                          1,266
Fibonacci:Iterative                       2,506                          2,506
Storage                                   3,671                          3,671
Fibonacci:Recursive                       3,794                          3,794
Computation                               5,776                          5,776
Fibonacci:Binet                           8,786                          8,786
large_div_rem                            10,705                          10,705
DivisionArithmetics                      14,831                          14,831
ERC20                                    32,288                          32,288
ERC20Tester                              34,589                          34,589
```