### PR TITLE
release resolc v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Supported `polkadot-sdk` rev: `2603`
 
+## v1.2.0
+
+- Supported `polkadot-sdk` rev: `2603`
+
 ### Changed
 
 - Updated `LLVM` from `21.1.8` to LLVM `22.1.4`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5091,7 +5091,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lld-sys"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "cc",
  "libc",
@@ -9347,7 +9347,7 @@ dependencies = [
 
 [[package]]
 name = "resolc"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -9389,11 +9389,11 @@ dependencies = [
 
 [[package]]
 name = "revive-build-utils"
-version = "1.1.0"
+version = "1.2.0"
 
 [[package]]
 name = "revive-builtins"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "revive-build-utils",
 ]
@@ -9425,7 +9425,7 @@ dependencies = [
 
 [[package]]
 name = "revive-integration"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -9453,7 +9453,7 @@ dependencies = [
 
 [[package]]
 name = "revive-llvm-builder"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9473,7 +9473,7 @@ dependencies = [
 
 [[package]]
 name = "revive-llvm-context"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -9494,7 +9494,7 @@ dependencies = [
 
 [[package]]
 name = "revive-runner"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -9514,7 +9514,7 @@ dependencies = [
 
 [[package]]
 name = "revive-runtime-api"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -9537,7 +9537,7 @@ dependencies = [
 
 [[package]]
 name = "revive-stdlib"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "inkwell",
  "revive-build-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9545,7 +9545,7 @@ dependencies = [
 
 [[package]]
 name = "revive-yul"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "inkwell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ revive-runner = { version = "1.1.0", path = "crates/runner" }
 revive-runtime-api = { version = "1.2.0", path = "crates/runtime-api" }
 revive-solc-json-interface = { version = "1.0.0", path = "crates/solc-json-interface", default-features = false }
 revive-stdlib = { version = "1.2.0", path = "crates/stdlib" }
-revive-yul = { version = "1.1.0", path = "crates/yul" }
+revive-yul = { version = "1.2.0", path = "crates/yul" }
 
 hex = "0.4.3"
 cc = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,20 @@ repository = "https://github.com/paritytech/revive"
 rust-version = "1.85.0"
 
 [workspace.dependencies]
-lld-sys = { version = "1.1.0", path = "crates/lld-sys" }
-resolc = { version = "1.1.0", path = "crates/resolc", default-features = false }
+lld-sys = { version = "1.2.0", path = "crates/lld-sys" }
+resolc = { version = "1.2.0", path = "crates/resolc", default-features = false }
 revive-benchmarks = { version = "1.0.0", path = "crates/benchmarks" }
-revive-build-utils = { version = "1.1.0", path = "crates/build-utils" }
-revive-builtins = { version = "1.0.0", path = "crates/builtins" }
+revive-build-utils = { version = "1.2.0", path = "crates/build-utils" }
+revive-builtins = { version = "1.1.0", path = "crates/builtins" }
 revive-common = { version = "1.0.0", path = "crates/common" }
 revive-differential = { version = "1.0.0", path = "crates/differential" }
-revive-integration = { version = "1.1.0", path = "crates/integration" }
+revive-integration = { version = "1.2.0", path = "crates/integration" }
 revive-linker = { version = "1.0.0", path = "crates/linker" }
-revive-llvm-context = { version = "1.1.0", path = "crates/llvm-context" }
+revive-llvm-context = { version = "1.2.0", path = "crates/llvm-context" }
 revive-runner = { version = "1.1.0", path = "crates/runner" }
-revive-runtime-api = { version = "1.1.0", path = "crates/runtime-api" }
+revive-runtime-api = { version = "1.2.0", path = "crates/runtime-api" }
 revive-solc-json-interface = { version = "1.0.0", path = "crates/solc-json-interface", default-features = false }
-revive-stdlib = { version = "1.1.0", path = "crates/stdlib" }
+revive-stdlib = { version = "1.2.0", path = "crates/stdlib" }
 revive-yul = { version = "1.1.0", path = "crates/yul" }
 
 hex = "0.4.3"

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-build-utils"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/builtins/Cargo.toml
+++ b/crates/builtins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-builtins"
-version.workspace = true
+version = "1.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/integration/Cargo.toml
+++ b/crates/integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-integration"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/lld-sys/Cargo.toml
+++ b/crates/lld-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lld-sys"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/llvm-builder/Cargo.toml
+++ b/crates/llvm-builder/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Anton Baliasnikov <aba@matterlabs.dev>",
     "Cyrill Leutwiler <cyrill@parity.io>",
 ]
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/llvm-context/Cargo.toml
+++ b/crates/llvm-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-llvm-context"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/resolc/Cargo.toml
+++ b/crates/resolc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolc"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-runner"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/runtime-api/Cargo.toml
+++ b/crates/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-runtime-api"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-stdlib"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/yul/Cargo.toml
+++ b/crates/yul/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revive-yul"
 description = "The revive YUL parser library."
-version = "1.1.0"
+version = "1.2.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Supported `polkadot-sdk` rev: `2603`

### Changed

- Updated `LLVM` from `21.1.8` to LLVM `22.1.4`

### Added

- Support for solc v0.8.35.

### Fixed

- A constant folding bug causing incorrect translation of a signed remainder edge case. The affected pattern (Solidity % or Yul smod):
  - SREM over the two constant operands `type(int256).min` and `-1`.
  - At least one of the two constants needs folding (i.e. not just `type(int256).min % -1`),
    and is written specifically such that solc doesn't fold but LLVM does, resulting in UB (signed-overflow).
- Fix `mulmod` returning out-of-range result for large moduli.