### PR TITLE
CI: Do not trigger release workflow on pushes to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Build
         run: |
-          cp -f --remove-destination resolc.{wasm,js} js/resolc/src/resolc/
+          cp --remove-destination resolc.{wasm,js} js/resolc/src/resolc/
           npm -w js/resolc run build
 
       - name: npm pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Build
         run: |
-          cp -f resolc.{wasm,js} js/resolc/src/resolc
+          cp -f --remove-destination resolc.{wasm,js} js/resolc/src/resolc/
           npm -w js/resolc run build
 
       - name: npm pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Build & Release
 
 on:
   push:
-    branches: ["main"]
     tags:
       - "v*"
   pull_request:


### PR DESCRIPTION
 Drop main push trigger from release workflow to avoid tag-run cancellation.