### PR TITLE
Fix `resolc-bin` push auth

### DIFF
--- a/.github/workflows/generate_versions.yml
+++ b/.github/workflows/generate_versions.yml
@@ -17,13 +17,7 @@ jobs:
         with:
           path: tmp
 
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          repository: paritytech/resolc-bin
-          path: resolc-bin
-
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.REVIVE_JSON_APP_ID }}
@@ -31,12 +25,16 @@ jobs:
           owner: paritytech
           repositories: resolc-bin
 
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          repository: paritytech/resolc-bin
+          path: resolc-bin
+          token: ${{ steps.app-token.outputs.token }}
+
       - name: Generate json and push
         env:
-          TOKEN: ${{ steps.app-token.outputs.token }}
           APP_NAME: "paritytech-revive-json"
-          Green: "\e[32m"
-          NC: "\e[0m"
         run: |
           sudo apt-get update && sudo apt-get install -y wget
           wget https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/resolc-x86_64-unknown-linux-musl
@@ -50,13 +48,6 @@ jobs:
           # Update GitHub Pages file with the JSON data.
           chmod +x ../tmp/.github/scripts/resolc-bin-gh-pages.sh
           bash ../tmp/.github/scripts/resolc-bin-gh-pages.sh $PWD
-
-          echo "${Green}Add new remote with gh app token${NC}"
-          git remote set-url origin $(git config remote.origin.url | sed "s/github.com/${APP_NAME}:${TOKEN}@github.com/g")
-
-          echo "${Green}Remove http section that causes issues with gh app auth token${NC}"
-          sed -i.bak '/\[http/d' ./.git/config
-          sed -i.bak '/extraheader/d' ./.git/config
 
           git config user.email "ci@parity.io"
           git config user.name "${APP_NAME}"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -64,19 +64,7 @@ jobs:
         with:
           path: revive
 
-      - name: Checkout resolc-bin
-        uses: actions/checkout@v6
-        with:
-          repository: paritytech/resolc-bin
-          path: resolc-bin
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v7
-        with:
-          merge-multiple: true
-          path: bins
-
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.REVIVE_JSON_APP_ID }}
@@ -84,13 +72,23 @@ jobs:
           owner: paritytech
           repositories: resolc-bin
 
+      - name: Checkout resolc-bin
+        uses: actions/checkout@v6
+        with:
+          repository: paritytech/resolc-bin
+          path: resolc-bin
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v7
+        with:
+          merge-multiple: true
+          path: bins
+
       - name: Generate JSON
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TOKEN: ${{ steps.app-token.outputs.token }}
           APP_NAME: "paritytech-revive-json"
-          Green: "\e[32m"
-          NC: "\e[0m"
         run: |
           # Rename resolc-web_js_* output keys to resolc-web.js_* expected by the script.
           echo '${{ toJSON(needs.build.outputs) }}' \
@@ -110,13 +108,6 @@ jobs:
           chmod +x ../revive/.github/scripts/resolc-bin-gh-pages.sh
           bash ../revive/.github/scripts/resolc-bin-gh-pages.sh $PWD
           git status
-
-          echo "${Green}Add new remote with gh app token${NC}"
-          git remote set-url origin $(git config remote.origin.url | sed "s/github.com/${APP_NAME}:${TOKEN}@github.com/g")
-
-          echo "${Green}Remove http section that causes issues with gh app auth token${NC}"
-          sed -i.bak '/\[http/d' ./.git/config
-          sed -i.bak '/extraheader/d' ./.git/config
 
           git config user.email "ci@parity.io"
           git config user.name "${APP_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           sha256sum resolc.wasm >> checksums.txt
           sha256sum resolc_web.js >> checksums.txt
 
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.REVIVE_RELEASE_APP_ID }}


### PR DESCRIPTION
Pushes to `resolc-bin` 403ed after bumping `actions/checkout` to `v6` (detected by [failure of the nightly release](https://github.com/paritytech/revive/actions/runs/27049132601/job/79841157330)). This PR now passes the app token to the resolc-bin checkout via [`token:`](https://github.com/actions/checkout/blob/df4cb1c069e1874edd31b4311f1884172cec0e10/README.md?plain=1#L66-L76) and drops the remote-URL/sed workaround.