### PR TITLE
Fix Wasm build cache collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [check-version-changed]
     uses: ./.github/workflows/reusable-build.yml
     with:
-      is_release: true
+      is_release: ${{ startsWith(github.ref_name, 'v') }}
       retention_days: 1
 
   create-release:

--- a/.github/workflows/reusable-build-wasm.yml
+++ b/.github/workflows/reusable-build-wasm.yml
@@ -32,7 +32,7 @@ jobs:
       resolc_web_js_sha: ${{ steps.upload-web-js.outputs.artifact-digest }}
     concurrency:
       # Use `reusable-build` and not `${{ github.workflow }}` here so that callers share the same concurrency group.
-      group: reusable-build-wasm32-unknown-emscripten-${{ github.sha }}
+      group: reusable-build-wasm32-unknown-emscripten-is-release-${{ inputs.is_release }}-${{ github.sha }}
       cancel-in-progress: false
     steps:
       - name: Checkout revive
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: resolc-${{ env.EMSCRIPTEN_TARGET }}
-          key: build-${{ env.EMSCRIPTEN_TARGET }}-${{ github.sha }}
+          key: build-${{ env.EMSCRIPTEN_TARGET }}-is-release-${{ inputs.is_release }}-${{ github.sha }}
 
       - name: Set Up Rust Toolchain
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Description

Before the CI refactor, the Wasm builds initiated by `release.yml` and `test-wasm.yml` ran in parallel, building duplicate builds. After the CI refactor, those workflows shared the build cache key to instead reuse the build. In both cases, the resolc Wasm URI baked into `resolc_web.js` depends on whether it is a release or not.

If the Wasm build step initiated by `release.yml` started *before* `test-wasm.yml`, `test-wasm.yml` would use an incorrect cache due to the invalid resolc Wasm URI (seen by [this failed run](https://github.com/paritytech/revive/actions/runs/27178950108/job/80235255116?pr=529)).

This PR updates the workflow input `is_release` to only pertain to ref names starting with `v` (which is what the `create-release` step guards on), and updates the cache key and concurrency group to include `is_release`, solving the cache collision. (Thus, the workflows needing a Wasm build for non-v-releases will still reuse the now-correct cache.)