### PR TITLE
Extend differential tests with newyork optimizer

### DIFF
--- a/.github/workflows/differential-tests.yml
+++ b/.github/workflows/differential-tests.yml
@@ -6,9 +6,10 @@ on:
 env:
   IS_PUSH_TO_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   # The exact compiler modes to use for compiling and comparing hashes by retester.
-  COMPILE_MODES: "Y M0 S+, Y M3 S+, Y Mz S+, NY Mz S+"
+  COMPILE_MODES: "NY M0 S+, NY M3 S+, NY Mz S+, NY M0 S-, NY M3 S-, NY Mz S-"
   # The compiler modes allowed to run during e2e test execution by retester.
-  E2E_ALLOWED_MODES: "Y, NY Mz S+, NY Mz S-"
+  # E.g. this can be updated to allow only `"Y, NY Mz S+"` (all Yul modes + newyork with -Oz and solc optimizer enabled).
+  E2E_ALLOWED_MODES: "Y, NY"
   SOLC_VERSION: "0.8.35"
 
 jobs:

--- a/.github/workflows/differential-tests.yml
+++ b/.github/workflows/differential-tests.yml
@@ -6,7 +6,11 @@ on:
 env:
   IS_PUSH_TO_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   # The exact compiler modes to use for compiling and comparing hashes by retester.
-  COMPILE_MODES: "Y M0 S+, Y M3 S+, Y Mz S+, NY M3 S+, NY Mz S+"
+  # Runs triggered by pushes to main exercise more modes.
+  COMPILE_MODES: >-
+    ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    && 'Y M0 S+, Y M3 S+, Y Mz S+, NY M0 S+, NY M3 S+, NY Mz S+'
+    || 'Y M0 S+, Y M3 S+, Y Mz S+, NY Mz S+' }}
   # The compiler modes allowed to run during e2e test execution by retester.
   # E.g. this can be updated to allow only `"Y, NY Mz S+"` (all Yul modes + newyork with -Oz and solc optimizer enabled).
   E2E_ALLOWED_MODES: "Y, NY"

--- a/.github/workflows/differential-tests.yml
+++ b/.github/workflows/differential-tests.yml
@@ -6,7 +6,7 @@ on:
 env:
   IS_PUSH_TO_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
   # The exact compiler modes to use for compiling and comparing hashes by retester.
-  COMPILE_MODES: "NY M0 S+, NY M3 S+, NY Mz S+, NY M0 S-, NY M3 S-, NY Mz S-"
+  COMPILE_MODES: "Y M0 S+, Y M3 S+, Y Mz S+, NY M3 S+, NY Mz S+"
   # The compiler modes allowed to run during e2e test execution by retester.
   # E.g. this can be updated to allow only `"Y, NY Mz S+"` (all Yul modes + newyork with -Oz and solc optimizer enabled).
   E2E_ALLOWED_MODES: "Y, NY"
@@ -204,6 +204,7 @@ jobs:
           resolc-path: ./resolc-bin/resolc-x86_64-unknown-linux-musl
           solc-version: ${{ env.SOLC_VERSION }}
           allowed-modes: ${{ env.E2E_ALLOWED_MODES }}
+          use-compilation-caches: false
           expectations-file-path: ./revive/.github/assets/revive-dev-node-polkavm-resolc.json
           # Use a sane value which is fast enough to make the tests run fast but not too
           # fast that it overwhelms the node.

--- a/.github/workflows/differential-tests.yml
+++ b/.github/workflows/differential-tests.yml
@@ -5,8 +5,10 @@ on:
 
 env:
   IS_PUSH_TO_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-  # The compiler modes to use for compilation by retester.
-  MODES: "Y M0 S+, Y M3 S+, Y Mz S+"
+  # The exact compiler modes to use for compiling and comparing hashes by retester.
+  COMPILE_MODES: "Y M0 S+, Y M3 S+, Y Mz S+, NY Mz S+"
+  # The compiler modes allowed to run during e2e test execution by retester.
+  E2E_ALLOWED_MODES: "Y, NY Mz S+, NY Mz S-"
   SOLC_VERSION: "0.8.35"
 
 jobs:
@@ -97,7 +99,7 @@ jobs:
           revive-differential-tests-path: revive/revive-differential-tests
           resolc-path: resolc-bin/resolc-${{ matrix.target }}${{ runner.os == 'Windows' && '.exe' || '' }}
           solc-version: ${{ env.SOLC_VERSION }}
-          modes: ${{ env.MODES }}
+          modes: ${{ env.COMPILE_MODES }}
           upload-artifact-name: compilation-report-${{ matrix.platform }}
 
       - name: Export Bytecode Hashes
@@ -128,7 +130,7 @@ jobs:
             hashes-macos-arm64,
             ${{ env.IS_PUSH_TO_MAIN == 'true' && 'hashes-macos-x86_64,' || '' }}
             hashes-windows-x86_64
-          modes: ${{ env.MODES }}
+          modes: ${{ env.COMPILE_MODES }}
           upload-artifact-name: hash-comparison-result
 
   run-e2e-tests:
@@ -200,6 +202,7 @@ jobs:
           platform: revive-dev-node-polkavm-resolc
           resolc-path: ./resolc-bin/resolc-x86_64-unknown-linux-musl
           solc-version: ${{ env.SOLC_VERSION }}
+          allowed-modes: ${{ env.E2E_ALLOWED_MODES }}
           expectations-file-path: ./revive/.github/assets/revive-dev-node-polkavm-resolc.json
           # Use a sane value which is fast enough to make the tests run fast but not too
           # fast that it overwhelms the node.


### PR DESCRIPTION
## Description

Extends our differential tests such that the compile+compare bytecode hashes and the E2E tests also exercise the newyork IR pipeline.

The requested compiler modes that E2E test cases run with are still controlled by the metadata in the corpus, but the related PR listed below also enables support for an allow-list to optionally narrow the set of modes run, via an input to the GH action used.

The changes to the workflow in this PR allows all newyork retester compiler modes (all LLVM opt levels + solc optimizer on/off) to run for the E2E tests since they still complete fast.

## Related

The PRs implemented as prerequisites alongside this PR are:
* `revive-differential-tests`
  * [Support optimized newyork IR compiler pipeline](https://github.com/paritytech/revive-differential-tests/pull/308)
* `resolc-compiler-tests`
  * [Add newyork IR pipeline counterparts for explicitly-listed Yul modes](https://github.com/paritytech/resolc-compiler-tests/pull/15)

## Resolved issues

Closes #553