### PR TITLE
Restore resolc long version onto standard JSON and combined JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Supported `polkadot-sdk` rev: `2604.2.0`
 
+### Fixed
+
+- Restored the top-level `revive_version` field in `--standard-json` output and the `resolc_version` field in `--combined-json` output, both of which stopped being populated in `v0.4.0`. [#557](https://github.com/paritytech/revive/pull/557)
+
 ## v1.3.0
 
 Supported `polkadot-sdk` rev: `2604.2.0`

--- a/crates/resolc/src/lib.rs
+++ b/crates/resolc/src/lib.rs
@@ -248,6 +248,7 @@ pub fn standard_json<T: Compiler>(
         include_paths,
         allow_paths,
     )?;
+    solc_output.revive_version = Some(ResolcVersion::default().long);
     solc_output.resolc_pipeline = Some(pipeline_name(use_newyork).to_owned());
 
     if language == SolcStandardJsonInputLanguage::Yul {
@@ -352,6 +353,7 @@ pub fn combined_json<T: Compiler>(
     }
 
     let mut combined_json = solc.combined_json(paths, selectors)?;
+    combined_json.resolc_version = Some(ResolcVersion::default().long);
     standard_output(
         solc,
         paths,

--- a/crates/resolc/src/tests/cli/combined_json.rs
+++ b/crates/resolc/src/tests/cli/combined_json.rs
@@ -1,11 +1,12 @@
 //! The tests for running resolc with combined JSON option.
 
-use revive_solc_json_interface::CombinedJsonInvalidSelectorMessage;
+use revive_solc_json_interface::{combined_json::CombinedJson, CombinedJsonInvalidSelectorMessage};
 
 use crate::cli_utils::{
-    assert_command_failure, assert_equal_exit_codes, execute_resolc, execute_solc,
-    SOLIDITY_CONTRACT_PATH, YUL_CONTRACT_PATH,
+    assert_command_failure, assert_command_success, assert_equal_exit_codes, execute_resolc,
+    execute_solc, SOLIDITY_CONTRACT_PATH, YUL_CONTRACT_PATH,
 };
+use crate::ResolcVersion;
 
 const JSON_OPTION: &str = "--combined-json";
 const JSON_ARGUMENTS: &[&str] = &[
@@ -117,4 +118,23 @@ fn fails_with_yul_input_file() {
         let solc_result = execute_solc(arguments);
         assert_equal_exit_codes(&solc_result, &resolc_result);
     }
+}
+
+#[test]
+fn populates_output_metadata_fields() {
+    let arguments = &[SOLIDITY_CONTRACT_PATH, JSON_OPTION, JSON_ARGUMENTS[0]];
+    let result = execute_resolc(arguments);
+    assert_command_success(&result, "Compiling with combined JSON");
+
+    let combined_json: CombinedJson =
+        serde_json::from_str(&result.stdout).expect("Combined JSON output should deserialize");
+    assert_eq!(
+        combined_json.resolc_version.as_deref(),
+        Some(ResolcVersion::default().long.as_str()),
+        "Combined JSON output should populate `resolc_version`"
+    );
+    assert!(
+        !combined_json.version.is_empty(),
+        "Combined JSON output should populate `version`"
+    );
 }

--- a/crates/resolc/src/tests/cli/standard_json.rs
+++ b/crates/resolc/src/tests/cli/standard_json.rs
@@ -15,6 +15,7 @@ use crate::cli_utils::{
     STANDARD_JSON_YUL_NEWYORK_DISABLED_PATH, STANDARD_JSON_YUL_NEWYORK_ENABLED_PATH,
     STANDARD_JSON_YUL_NO_PVM_CODEGEN_PATH, STANDARD_JSON_YUL_PVM_CODEGEN_PATH,
 };
+use crate::{pipeline_name, ResolcVersion};
 
 const JSON_OPTION: &str = "--standard-json";
 
@@ -639,4 +640,38 @@ fn pvm_codegen_newyork_yul_input() {
         bytecode_object(&disabled_output, "Test", "Test"),
         "settings.polkavm.newyork should select a different pipeline for Yul input"
     );
+}
+
+#[test]
+fn populates_output_metadata_fields() {
+    for (path, use_newyork) in [
+        (STANDARD_JSON_CONTRACTS_PATH, false),
+        (STANDARD_JSON_NEWYORK_ENABLED_PATH, true),
+        (STANDARD_JSON_NEWYORK_DISABLED_PATH, false),
+    ] {
+        let result = execute_resolc_with_stdin_input(&[JSON_OPTION], path);
+        assert_command_success(&result, "Compiling with standard JSON");
+
+        let output = to_solc_standard_json_output(&result.stdout);
+        assert_no_errors(&output);
+
+        assert_eq!(
+            output.revive_version.as_deref(),
+            Some(ResolcVersion::default().long.as_str()),
+            "Standard JSON output for `{path}` should populate `revive_version`"
+        );
+        assert_eq!(
+            output.resolc_pipeline.as_deref(),
+            Some(pipeline_name(use_newyork)),
+            "Standard JSON output for `{path}` should report the correct `resolc_pipeline`"
+        );
+        assert!(
+            output.version.is_some(),
+            "Standard JSON output for `{path}` should populate `version`"
+        );
+        assert!(
+            output.long_version.is_some(),
+            "Standard JSON output for `{path}` should populate `long_version`"
+        );
+    }
 }


### PR DESCRIPTION
## Description

The resolc long version stopped being populated on the standard JSON and combined JSON output. This PR restores these fields and populates them.