### PR TITLE
release resolc v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.4.0
 
 Supported `polkadot-sdk` rev: `2604.2.0`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9427,7 +9427,7 @@ dependencies = [
 
 [[package]]
 name = "resolc"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -9481,7 +9481,7 @@ dependencies = [
 
 [[package]]
 name = "revive-common"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -9506,7 +9506,7 @@ dependencies = [
 
 [[package]]
 name = "revive-integration"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -9534,7 +9534,7 @@ dependencies = [
 
 [[package]]
 name = "revive-llvm-builder"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "revive-newyork"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -9640,7 +9640,7 @@ dependencies = [
 
 [[package]]
 name = "revive-yul"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "inkwell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,21 +15,21 @@ rust-version = "1.91.0"
 
 [workspace.dependencies]
 lld-sys = { version = "1.2.0", path = "crates/lld-sys" }
-resolc = { version = "1.3.0", path = "crates/resolc", default-features = false }
+resolc = { version = "1.4.0", path = "crates/resolc", default-features = false }
 revive-benchmarks = { version = "1.1.0", path = "crates/benchmarks" }
 revive-build-utils = { version = "1.2.0", path = "crates/build-utils" }
 revive-builtins = { version = "1.1.0", path = "crates/builtins" }
-revive-common = { version = "1.1.0", path = "crates/common" }
+revive-common = { version = "1.2.0", path = "crates/common" }
 revive-differential = { version = "1.0.0", path = "crates/differential" }
-revive-integration = { version = "1.3.0", path = "crates/integration" }
+revive-integration = { version = "1.4.0", path = "crates/integration" }
 revive-linker = { version = "1.0.0", path = "crates/linker" }
 revive-llvm-context = { version = "1.3.0", path = "crates/llvm-context" }
-revive-newyork = { version = "1.0.0", path = "crates/newyork" }
+revive-newyork = { version = "1.1.0", path = "crates/newyork" }
 revive-runner = { version = "1.3.0", path = "crates/runner" }
 revive-runtime-api = { version = "1.3.0", path = "crates/runtime-api" }
 revive-solc-json-interface = { version = "1.1.0", path = "crates/solc-json-interface", default-features = false }
 revive-stdlib = { version = "1.2.0", path = "crates/stdlib" }
-revive-yul = { version = "1.3.0", path = "crates/yul" }
+revive-yul = { version = "1.4.0", path = "crates/yul" }
 
 hex = "0.4.3"
 cc = "1.2"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-common"
-version = "1.1.0"
+version = "1.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/integration/Cargo.toml
+++ b/crates/integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revive-integration"
-version = "1.3.0"
+version = "1.4.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/llvm-builder/Cargo.toml
+++ b/crates/llvm-builder/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Anton Baliasnikov <aba@matterlabs.dev>",
     "Cyrill Leutwiler <cyrill@parity.io>",
 ]
-version = "1.2.0"
+version = "1.3.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/newyork/Cargo.toml
+++ b/crates/newyork/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revive-newyork"
 description = "NEW Yul OptimizIR Kit - Custom IR layer for domain-specific optimizations"
-version = "1.0.0"
+version = "1.1.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/crates/resolc/Cargo.toml
+++ b/crates/resolc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolc"
-version = "1.3.0"
+version = "1.4.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/yul/Cargo.toml
+++ b/crates/yul/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revive-yul"
 description = "The revive YUL parser library."
-version = "1.3.0"
+version = "1.4.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/js/resolc/package.json
+++ b/js/resolc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parity/resolc",
   "license": "Apache-2.0",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Parity <admin@parity.io> (https://parity.io)",
   "module": "index.ts",
   "types": "./dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "js/resolc": {
       "name": "@parity/resolc",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^22.19.17",


### PR DESCRIPTION
resolc v1.4.0

Supported `polkadot-sdk` rev: `2604.2.0`

### Added
- Support for solc v0.8.36 and the "Amsterdam" EVM version.
### Fixed
- Restored the top-level `revive_version` field in `--standard-json` output and the `resolc_version` field in `--combined-json` output, both of which stopped being populated in `v0.4.0`. [#557](https://github.com/paritytech/revive/pull/557)
- ICE triggered by `--disable-solc-optimizer --newyork` where inlined loops could emit an unterminated basic block in the inlined entrypoint. [#561](https://github.com/paritytech/revive/pull/561)
- `--newyork`: dead-store elimination could drop a store whose memory expansion an intervening `msize()` observes, so `msize()` read a stale (unexpanded) value. [#565](https://github.com/paritytech/revive/pull/565)
- `--newyork`: dead-store elimination could drop a store that a later overlapping unaligned `mload` reads, returning zeroed memory instead of the stored bytes. [#563](https://github.com/paritytech/revive/pull/563)
- `--newyork`: an unaligned full-word `mload`/`mstore` overlapping a word kept native (little-endian) by the heap optimization returned byte-swapped bytes. [#562](https://github.com/paritytech/revive/pull/562)
- `--newyork`: a `calldatacopy`/`codecopy`/`returndatacopy` to a dynamic destination that could overwrite the free-memory-pointer word truncated a subsequent `mload(0x40)` to `0`. [#564](https://github.com/paritytech/revive/pull/564)
- `--newyork`: a full-width value stored to the free-memory-pointer slot (e.g. a function parameter `>= 2^64`) was narrowed to 64 bits, inserting a checked truncation that consumed all gas. [#567](https://github.com/paritytech/revive/pull/567)
- `--newyork`: an unaligned `mstore` corrupting the free-memory-pointer word let a later store through the corrupted pointer silently succeed where EVM runs out of gas. [#566](https://github.com/paritytech/revive/pull/566)
- Fixed a bytecode divergence (yet functionally equivalent) between the resolc Linux/macOS builds and the Windows build for contracts with loops indexing array elements at constant offsets from a `uint8` loop variable (e.g. `array[i]`/`array[i + 1]`), compiled with `--newyork` at `-Oz` with the solc optimizer disabled. [#570](https://github.com/paritytech/revive/pull/570)