### PR TITLE
Fix integer overflow in heap_opt range walk on top-of-memory access (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `--newyork`: an ICE ("attempt to add with overflow") while analyzing a static memory access at the top of the address space, reachable from valid Yul where an `mstore` corrupts the free-memory-pointer word and a later store is forwarded to `u64::MAX`. [#582](https://github.com/paritytech/revive/pull/582)
+
 ## v1.4.0
 
 Supported `polkadot-sdk` rev: `2604.2.0`

--- a/crates/integration/contracts/HeapRangeOverflowBug.yul
+++ b/crates/integration/contracts/HeapRangeOverflowBug.yul
@@ -1,0 +1,25 @@
+/// ICE regression (newyork heap analysis): the word walk over a static memory range must not
+/// overflow `u64` for an access at the top of the address space.
+///
+/// `add(mul(MAX_U256, 1), 0x41)` folds to `0x40`, so the second `mstore` writes `u64::MAX` over
+/// the free-memory-pointer word. `mem_opt` forwards `mload(0x40)` to that literal, turning
+/// `mstore(f2, _)` into a static store at `u64::MAX`, where the walk panicked with "attempt to
+/// add with overflow" on valid Yul. Compiling this at all is the regression; the run also pins
+/// the behaviour against EVM.
+object "HeapRangeOverflowBug" {
+  code { datacopy(0, dataoffset("HeapRangeOverflowBug_deployed"), datasize("HeapRangeOverflowBug_deployed")) return(0, datasize("HeapRangeOverflowBug_deployed")) }
+  object "HeapRangeOverflowBug_deployed" {
+    code {
+      mstore(0x40, 0x80)
+      mstore(add(mul(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1), 0x41),
+             0x000000000000000000000000000000000000000000000000ffffffffffffffff)
+      let fmp := mload(0x40)
+      let f2 := mload(0x40)
+      mstore(f2, 0xC0FFEE)
+      let rb := mload(f2)
+      mstore(0, fmp)
+      mstore(32, rb)
+      return(0, 64)
+    }
+  }
+}

--- a/crates/integration/src/tests.rs
+++ b/crates/integration/src/tests.rs
@@ -4908,6 +4908,25 @@ fn msize_observes_dead_store_expansion() {
     run_differential(actions);
 }
 
+/// ICE regression (newyork heap analysis): a static memory access at the top of the address space
+/// must not overflow the word walk. `add(mul(MAX_U256, 1), 0x41)` folds to `0x40`, corrupting the
+/// free-memory-pointer word with `u64::MAX`; `mem_opt` then forwards a store to that literal and
+/// the walk panicked with "attempt to add with overflow". Compiling is the regression; the call
+/// pins runtime behaviour against solc-EVM.
+#[test]
+fn heap_range_walk_at_top_of_memory() {
+    let mut actions = instantiate_yul("contracts/HeapRangeOverflowBug.yul", "HeapRangeOverflowBug");
+    actions.push(Call {
+        origin: TestAddress::Alice,
+        dest: TestAddress::Instantiated(0),
+        value: 0,
+        gas_limit: Some(GAS_LIMIT),
+        storage_deposit_limit: None,
+        data: vec![],
+    });
+    run_differential(actions);
+}
+
 /// Regression (newyork FMP range proof): a `calldatacopy` whose *dynamic*
 /// destination can land on the free-memory-pointer word `[0x40, 0x60)` corrupts
 /// the FMP, but only *static* copy destinations flagged `fmp_could_be_unbounded`.

--- a/crates/newyork/src/heap_opt.rs
+++ b/crates/newyork/src/heap_opt.rs
@@ -31,6 +31,32 @@ use revive_common::BYTE_LENGTH_WORD;
 /// this is treated as a dynamic escape instead.
 const MAX_RANGE_WORDS: u64 = 4096;
 
+/// The word-aligned words that `[address, address + size)` covers, start rounded down so a
+/// partial leading word is included: 32 bytes at `0x30` yields `0x20` and `0x40`.
+///
+/// [`None`] when the range exceeds [`MAX_RANGE_WORDS`]; callers then record only its first word
+/// and set their dynamic flag.
+///
+/// Stepping a bounded count saturatingly, rather than walking to a static end, is what keeps an
+/// access at the top of memory from overflowing `u64` — reachable from valid Yul via a corrupted
+/// free-memory pointer.
+fn range_words(address: u64, size: u64) -> Option<impl Iterator<Item = u64>> {
+    let first_word = word_align(address);
+    let num_words = address
+        .saturating_add(size)
+        .saturating_sub(first_word)
+        .saturating_add(BYTE_LENGTH_WORD as u64 - 1)
+        / BYTE_LENGTH_WORD as u64;
+
+    (num_words <= MAX_RANGE_WORDS).then(|| {
+        (0..num_words).scan(first_word, |word, _| {
+            let current = *word;
+            *word = word.saturating_add(BYTE_LENGTH_WORD as u64);
+            Some(current)
+        })
+    })
+}
+
 /// Classification of a memory access pattern.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum AccessPattern {
@@ -562,24 +588,13 @@ impl HeapAnalysis {
         let len = self.extract_static_offset(length);
         match (start, len) {
             (Some(_), Some(0)) => {}
-            (Some(address), Some(size)) => {
-                let end = address.saturating_add(size);
-                let first_word = word_align(address);
-                let range = end.saturating_sub(first_word);
-                let num_words =
-                    range.saturating_add(BYTE_LENGTH_WORD as u64 - 1) / BYTE_LENGTH_WORD as u64;
-                // Records each covered word; same range walk and corner cases as `taint_range`.
-                if num_words > MAX_RANGE_WORDS {
-                    self.escaping_regions.insert(first_word);
+            (Some(address), Some(size)) => match range_words(address, size) {
+                Some(words) => self.escaping_regions.extend(words),
+                None => {
+                    self.escaping_regions.insert(word_align(address));
                     self.has_dynamic_escapes = true;
-                } else {
-                    let mut word = first_word;
-                    for _ in 0..num_words {
-                        self.escaping_regions.insert(word);
-                        word = word.saturating_add(BYTE_LENGTH_WORD as u64);
-                    }
                 }
-            }
+            },
             (Some(address), None) => {
                 self.escaping_regions.insert(word_align(address));
                 self.has_dynamic_escapes = true;
@@ -704,40 +719,20 @@ impl HeapAnalysis {
         self.taint_range(Some(address), Some(BYTE_LENGTH_WORD as u64));
     }
 
-    /// Taints all word-aligned memory regions in a range.
-    /// If the range is too large, treats it as a dynamic access instead.
+    /// Taints the words a range covers, per [`range_words`].
+    ///
+    /// An over-wide range, a dynamic length, an unknown start, or an empty range all take the
+    /// dynamic path: the start word is tainted where known and `has_dynamic_accesses` is set. Note
+    /// `size == 0` taints the start word rather than nothing.
     fn taint_range(&mut self, start: Option<u64>, len: Option<u64>) {
         match (start, len) {
-            (Some(address), Some(size)) if size > 0 => {
-                let end = address.saturating_add(size);
-                let first_word = word_align(address);
-                let num_words = end
-                    .saturating_sub(first_word)
-                    .saturating_add(BYTE_LENGTH_WORD as u64 - 1)
-                    / BYTE_LENGTH_WORD as u64;
-                // `[address, address + size)` spans `num_words` 32-byte words starting at
-                // the word-aligned `first_word` (`address` rounded down, so a partial leading
-                // word is included). Record each covered word.
-                //
-                // Corner cases:
-                // - Huge ranges (`num_words > MAX_RANGE_WORDS`) would iterate too long, so they
-                //   collapse to the first word plus a dynamic-access flag instead.
-                // - An access near the top of memory saturates `end` at `u64::MAX` (e.g. an
-                //   unaligned store through a corrupted free-memory pointer). Stepping the
-                //   bounded `num_words` count with a saturating add keeps the final increment
-                //   from overflowing `u64` — a plain `word += 32` panics here.
-                // - `size == 0` is excluded by the match guard (an empty range taints nothing).
-                if num_words > MAX_RANGE_WORDS {
-                    self.tainted_regions.insert(first_word);
+            (Some(address), Some(size)) if size > 0 => match range_words(address, size) {
+                Some(words) => self.tainted_regions.extend(words),
+                None => {
+                    self.tainted_regions.insert(word_align(address));
                     self.has_dynamic_accesses = true;
-                } else {
-                    let mut word = first_word;
-                    for _ in 0..num_words {
-                        self.tainted_regions.insert(word);
-                        word = word.saturating_add(BYTE_LENGTH_WORD as u64);
-                    }
                 }
-            }
+            },
             (Some(address), _) => {
                 self.tainted_regions.insert(word_align(address));
                 self.has_dynamic_accesses = true;
@@ -1049,27 +1044,19 @@ impl HeapAnalysis {
         let start = self.extract_static_offset(offset);
         let len = self.extract_static_offset(length);
         match (start, len) {
-            (Some(address), Some(size)) if size > 0 => {
-                let end = address.saturating_add(size);
-                let first_word = word_align(address);
-                let num_words = end
-                    .saturating_sub(first_word)
-                    .saturating_add(BYTE_LENGTH_WORD as u64 - 1)
-                    / BYTE_LENGTH_WORD as u64;
-                // Records each covered word; same range walk and corner cases as `taint_range`.
-                if num_words > MAX_RANGE_WORDS {
-                    self.escaping_regions.insert(first_word);
-                    self.tainted_regions.insert(first_word);
-                    self.has_dynamic_escapes = true;
-                } else {
-                    let mut word = first_word;
-                    for _ in 0..num_words {
+            (Some(address), Some(size)) if size > 0 => match range_words(address, size) {
+                Some(words) => {
+                    for word in words {
                         self.escaping_regions.insert(word);
                         self.tainted_regions.insert(word);
-                        word = word.saturating_add(BYTE_LENGTH_WORD as u64);
                     }
                 }
-            }
+                None => {
+                    self.escaping_regions.insert(word_align(address));
+                    self.tainted_regions.insert(word_align(address));
+                    self.has_dynamic_escapes = true;
+                }
+            },
             (Some(address), None) => {
                 self.escaping_regions.insert(word_align(address));
                 self.tainted_regions.insert(word_align(address));
@@ -2154,18 +2141,128 @@ mod tests {
         assert!(analysis.has_dynamic_accesses);
     }
 
-    /// a static access near the top of the address space
-    /// saturates `end` at `u64::MAX`; the word walk must not overflow `u64`.
+    /// An access at the top of the address space must not overflow the word walk.
     #[test]
     fn taint_range_top_of_memory_does_not_overflow() {
         let mut analysis = HeapAnalysis::new();
-        // Unaligned (u64::MAX % 32 == 31) full-word store at the very top of memory —
-        // the shape mem_opt forwards from a corrupted free-memory pointer.
+        // The shape mem_opt forwards from a corrupted free-memory pointer.
         analysis.taint_range(Some(u64::MAX), Some(BYTE_LENGTH_WORD as u64));
         assert_eq!(
             analysis.tainted_regions,
             BTreeSet::from([word_align(u64::MAX)]),
             "only the single covered leading word is tainted"
+        );
+    }
+
+    /// A zero-length access still taints its start word, via the dynamic path.
+    #[test]
+    fn taint_range_empty_range_taints_the_start_word() {
+        let mut analysis = HeapAnalysis::new();
+        analysis.taint_range(Some(0x30), Some(0));
+        assert_eq!(analysis.tainted_regions, BTreeSet::from([0x20]));
+        assert!(analysis.has_dynamic_accesses);
+    }
+
+    /// Binds `id` to the static offset `value` so the range helpers can resolve it.
+    fn offset_value(analysis: &mut HeapAnalysis, id: u32, value: u64) -> Value {
+        use crate::ir::{Type, ValueId};
+        analysis.offset_values.insert(
+            id,
+            OffsetInfo {
+                static_value: Some(value),
+                ..Default::default()
+            },
+        );
+        Value::new(ValueId(id), Type::default())
+    }
+
+    /// Same words as `taint_range`, recorded as escaping; an over-wide range collapses.
+    #[test]
+    fn mark_escaping_range_covers_spanned_words() {
+        let mut analysis = HeapAnalysis::new();
+        let offset = offset_value(&mut analysis, 1, 0x30);
+        let length = offset_value(&mut analysis, 2, BYTE_LENGTH_WORD as u64);
+        analysis.mark_escaping_range(&offset, &length);
+        assert_eq!(analysis.escaping_regions, BTreeSet::from([0x20, 0x40]));
+        assert!(analysis.tainted_regions.is_empty());
+        assert!(!analysis.has_dynamic_escapes);
+
+        let mut analysis = HeapAnalysis::new();
+        let offset = offset_value(&mut analysis, 1, 0);
+        let length = offset_value(
+            &mut analysis,
+            2,
+            (MAX_RANGE_WORDS + 1) * BYTE_LENGTH_WORD as u64,
+        );
+        analysis.mark_escaping_range(&offset, &length);
+        assert_eq!(analysis.escaping_regions, BTreeSet::from([0]));
+        assert!(analysis.has_dynamic_escapes);
+    }
+
+    /// The overflowing range reaches this caller through the same helper.
+    #[test]
+    fn mark_escaping_range_top_of_memory_does_not_overflow() {
+        let mut analysis = HeapAnalysis::new();
+        let offset = offset_value(&mut analysis, 1, u64::MAX);
+        let length = offset_value(&mut analysis, 2, BYTE_LENGTH_WORD as u64);
+        analysis.mark_escaping_range(&offset, &length);
+        assert_eq!(
+            analysis.escaping_regions,
+            BTreeSet::from([word_align(u64::MAX)])
+        );
+    }
+
+    /// Every covered word lands in both sets.
+    #[test]
+    fn mark_escaping_and_tainted_range_covers_both_sets() {
+        let mut analysis = HeapAnalysis::new();
+        let offset = offset_value(&mut analysis, 1, 0x30);
+        let length = offset_value(&mut analysis, 2, BYTE_LENGTH_WORD as u64);
+        analysis.mark_escaping_and_tainted_range(&offset, &length);
+        assert_eq!(analysis.escaping_regions, BTreeSet::from([0x20, 0x40]));
+        assert_eq!(analysis.tainted_regions, BTreeSet::from([0x20, 0x40]));
+        assert!(!analysis.has_dynamic_escapes);
+    }
+
+    /// The overflowing range through the both-sets walk.
+    #[test]
+    fn mark_escaping_and_tainted_range_top_of_memory_does_not_overflow() {
+        let mut analysis = HeapAnalysis::new();
+        let offset = offset_value(&mut analysis, 1, u64::MAX);
+        let length = offset_value(&mut analysis, 2, BYTE_LENGTH_WORD as u64);
+        analysis.mark_escaping_and_tainted_range(&offset, &length);
+        let top = BTreeSet::from([word_align(u64::MAX)]);
+        assert_eq!(analysis.escaping_regions, top);
+        assert_eq!(analysis.tainted_regions, top);
+    }
+
+    /// The shared walk: coverage, the width cap, and the saturating step.
+    #[test]
+    fn range_words_walks_every_covered_word() {
+        let words = |address, size| range_words(address, size).map(Iterator::collect::<Vec<_>>);
+
+        // Mid-word start includes the partial leading word; a single byte touches its word.
+        assert_eq!(words(0x30, BYTE_LENGTH_WORD as u64), Some(vec![0x20, 0x40]));
+        assert_eq!(words(0, 2 * BYTE_LENGTH_WORD as u64), Some(vec![0, 0x20]));
+        assert_eq!(words(0x21, 1), Some(vec![0x20]));
+        // An empty range covers nothing; callers decide what that means.
+        assert_eq!(words(0x20, 0), Some(vec![]));
+
+        // At the cap is walked; one word beyond is not.
+        assert_eq!(
+            range_words(0, MAX_RANGE_WORDS * BYTE_LENGTH_WORD as u64).map(Iterator::count),
+            Some(MAX_RANGE_WORDS as usize)
+        );
+        assert!(range_words(0, (MAX_RANGE_WORDS + 1) * BYTE_LENGTH_WORD as u64).is_none());
+
+        // The regression: the step past the final word must saturate, not overflow.
+        assert_eq!(
+            words(u64::MAX, BYTE_LENGTH_WORD as u64),
+            Some(vec![word_align(u64::MAX)])
+        );
+        assert_eq!(
+            words(u64::MAX - 1, u64::MAX),
+            Some(vec![word_align(u64::MAX)])
         );
     }
 }

--- a/crates/newyork/src/heap_opt.rs
+++ b/crates/newyork/src/heap_opt.rs
@@ -568,14 +568,15 @@ impl HeapAnalysis {
                 let range = end.saturating_sub(first_word);
                 let num_words =
                     range.saturating_add(BYTE_LENGTH_WORD as u64 - 1) / BYTE_LENGTH_WORD as u64;
+                // Records each covered word; same range walk and corner cases as `taint_range`.
                 if num_words > MAX_RANGE_WORDS {
                     self.escaping_regions.insert(first_word);
                     self.has_dynamic_escapes = true;
                 } else {
                     let mut word = first_word;
-                    while word < end {
+                    for _ in 0..num_words {
                         self.escaping_regions.insert(word);
-                        word += BYTE_LENGTH_WORD as u64;
+                        word = word.saturating_add(BYTE_LENGTH_WORD as u64);
                     }
                 }
             }
@@ -714,14 +715,26 @@ impl HeapAnalysis {
                     .saturating_sub(first_word)
                     .saturating_add(BYTE_LENGTH_WORD as u64 - 1)
                     / BYTE_LENGTH_WORD as u64;
+                // `[address, address + size)` spans `num_words` 32-byte words starting at
+                // the word-aligned `first_word` (`address` rounded down, so a partial leading
+                // word is included). Record each covered word.
+                //
+                // Corner cases:
+                // - Huge ranges (`num_words > MAX_RANGE_WORDS`) would iterate too long, so they
+                //   collapse to the first word plus a dynamic-access flag instead.
+                // - An access near the top of memory saturates `end` at `u64::MAX` (e.g. an
+                //   unaligned store through a corrupted free-memory pointer). Stepping the
+                //   bounded `num_words` count with a saturating add keeps the final increment
+                //   from overflowing `u64` — a plain `word += 32` panics here.
+                // - `size == 0` is excluded by the match guard (an empty range taints nothing).
                 if num_words > MAX_RANGE_WORDS {
                     self.tainted_regions.insert(first_word);
                     self.has_dynamic_accesses = true;
                 } else {
                     let mut word = first_word;
-                    while word < end {
+                    for _ in 0..num_words {
                         self.tainted_regions.insert(word);
-                        word += BYTE_LENGTH_WORD as u64;
+                        word = word.saturating_add(BYTE_LENGTH_WORD as u64);
                     }
                 }
             }
@@ -1043,16 +1056,17 @@ impl HeapAnalysis {
                     .saturating_sub(first_word)
                     .saturating_add(BYTE_LENGTH_WORD as u64 - 1)
                     / BYTE_LENGTH_WORD as u64;
+                // Records each covered word; same range walk and corner cases as `taint_range`.
                 if num_words > MAX_RANGE_WORDS {
                     self.escaping_regions.insert(first_word);
                     self.tainted_regions.insert(first_word);
                     self.has_dynamic_escapes = true;
                 } else {
                     let mut word = first_word;
-                    while word < end {
+                    for _ in 0..num_words {
                         self.escaping_regions.insert(word);
                         self.tainted_regions.insert(word);
-                        word += BYTE_LENGTH_WORD as u64;
+                        word = word.saturating_add(BYTE_LENGTH_WORD as u64);
                     }
                 }
             }
@@ -2107,6 +2121,51 @@ mod tests {
         assert!(
             !after.can_use_native(0x80),
             "post-dedup native mode must be disabled for the now-variable offset word"
+        );
+    }
+
+    /// `taint_range` taints exactly the word-aligned words a static range covers,
+    /// including the partial leading word when the start is unaligned.
+    #[test]
+    fn taint_range_covers_spanned_words() {
+        // Aligned two-word range [0, 64).
+        let mut analysis = HeapAnalysis::new();
+        analysis.taint_range(Some(0), Some(2 * BYTE_LENGTH_WORD as u64));
+        assert_eq!(
+            analysis.tainted_regions,
+            BTreeSet::from([0, BYTE_LENGTH_WORD as u64])
+        );
+        assert!(!analysis.has_dynamic_accesses);
+
+        // A 32-byte access at the unaligned 0x30 spans words 0x20 and 0x40.
+        let mut analysis = HeapAnalysis::new();
+        analysis.taint_range(Some(0x30), Some(BYTE_LENGTH_WORD as u64));
+        assert_eq!(analysis.tainted_regions, BTreeSet::from([0x20, 0x40]));
+    }
+
+    /// A range wider than `MAX_RANGE_WORDS` collapses to the first word plus a
+    /// dynamic-access flag rather than iterating every word.
+    #[test]
+    fn taint_range_huge_range_is_treated_as_dynamic() {
+        let mut analysis = HeapAnalysis::new();
+        let huge = (MAX_RANGE_WORDS + 1) * BYTE_LENGTH_WORD as u64;
+        analysis.taint_range(Some(0), Some(huge));
+        assert_eq!(analysis.tainted_regions, BTreeSet::from([0]));
+        assert!(analysis.has_dynamic_accesses);
+    }
+
+    /// a static access near the top of the address space
+    /// saturates `end` at `u64::MAX`; the word walk must not overflow `u64`.
+    #[test]
+    fn taint_range_top_of_memory_does_not_overflow() {
+        let mut analysis = HeapAnalysis::new();
+        // Unaligned (u64::MAX % 32 == 31) full-word store at the very top of memory —
+        // the shape mem_opt forwards from a corrupted free-memory pointer.
+        analysis.taint_range(Some(u64::MAX), Some(BYTE_LENGTH_WORD as u64));
+        assert_eq!(
+            analysis.tainted_regions,
+            BTreeSet::from([word_align(u64::MAX)]),
+            "only the single covered leading word is tainted"
         );
     }
 }


### PR DESCRIPTION
…#581)

The word-stepping loops in `taint_range`, `mark_escaping_range`, and `mark_escaping_and_tainted_range` walked a static range with `while word < end { word += 32 }`. When an access sits near the top of the address space, `end = address.saturating_add(size)` saturates at `u64::MAX`, and the final `word += 32` steps past `u64::MAX`, panicking with "attempt to add with overflow".

Under `--newyork` this is reachable from valid Yul: folding `add(mul(MAX_U256, 1), 0x41)` to `0x40` lets an mstore corrupt the free-memory-pointer word with `u64::MAX`; mem_opt then forwards `mload(0x40)` to that literal, turning a later `mstore(fmp, _)` into a static unaligned store at `u64::MAX` that taints its covered words.

Iterate the already-bounded `num_words` count with a saturating step so the walk covers the same words without overflowing.