### PR TITLE
Allow using the custom wide integer instructions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "llvm"]
 	path = llvm
-	url = https://github.com/llvm/llvm-project.git
-	branch = release/21.x
+	url = https://github.com/paritytech/llvm-project.git
 [submodule "revive-differential-tests"]
 	path = revive-differential-tests
 	url = https://github.com/paritytech/revive-differential-tests.git

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ install-llvm-builder:
 	cargo install --force --locked --path crates/llvm-builder
 
 install-llvm: install-llvm-builder
+	git submodule sync --recursive
 	git submodule update --init --recursive --depth 1
 	revive-llvm build --llvm-projects lld --llvm-projects clang
 
@@ -54,6 +55,7 @@ install-llvm: install-llvm-builder
 # Shares the `target-llvm/<env>/` tree with `install-llvm`.
 # Run `revive-llvm clean` between variants. `JOBS=N` caps build parallelism.
 install-llvm-coverage: install-llvm-builder
+	git submodule sync --recursive
 	git submodule update --init --recursive --depth 1
 	CMAKE_BUILD_PARALLEL_LEVEL=$(JOBS) revive-llvm build --llvm-projects lld --llvm-projects clang --enable-coverage
 

--- a/crates/llvm-context/src/lib.rs
+++ b/crates/llvm-context/src/lib.rs
@@ -123,7 +123,8 @@ const SIZE_LEVEL_Z_ARGUMENTS: &[&str] = &[
 
 /// Initializes the LLVM compiler backend.
 ///
-/// This is a no-op if called subsequentially.
+/// Subsequent calls are a no-op, except that a call arriving while another thread is still
+/// initializing blocks until that thread finishes.
 ///
 /// `llvm_arguments` are passed as-is to the LLVM CL options parser.
 ///
@@ -140,33 +141,34 @@ pub fn initialize_llvm(
     use_newyork: bool,
     llvm_arguments: &[String],
 ) {
-    let Ok(_) = DID_INITIALIZE.set(()) else {
-        return; // Tests don't go through a recursive process
-    };
+    // `get_or_init` rather than `set`, so that a caller arriving while another thread is still
+    // initializing blocks until it finishes rather than proceeding against an unregistered
+    // target. Only parallel test binaries call this concurrently.
+    DID_INITIALIZE.get_or_init(|| {
+        let size_arguments = if use_newyork && size_level == OptimizerSettingsSizeLevel::Z {
+            SIZE_LEVEL_Z_ARGUMENTS
+        } else {
+            &[]
+        };
+        let argv = std::iter::once(name)
+            .chain(size_arguments.iter().copied())
+            .chain(llvm_arguments.iter().map(String::as_str))
+            .map(|arg| CString::new(arg.as_bytes()).unwrap())
+            .collect::<Vec<_>>();
+        let argv: Vec<*const libc::c_char> = argv.iter().map(|arg| arg.as_ptr()).collect();
+        let overview = CString::new("").unwrap();
+        unsafe {
+            inkwell::llvm_sys::support::LLVMParseCommandLineOptions(
+                argv.len() as i32,
+                argv.as_ptr(),
+                overview.as_ptr(),
+            );
+        }
 
-    let size_arguments = if use_newyork && size_level == OptimizerSettingsSizeLevel::Z {
-        SIZE_LEVEL_Z_ARGUMENTS
-    } else {
-        &[]
-    };
-    let argv = std::iter::once(name)
-        .chain(size_arguments.iter().copied())
-        .chain(llvm_arguments.iter().map(String::as_str))
-        .map(|arg| CString::new(arg.as_bytes()).unwrap())
-        .collect::<Vec<_>>();
-    let argv: Vec<*const libc::c_char> = argv.iter().map(|arg| arg.as_ptr()).collect();
-    let overview = CString::new("").unwrap();
-    unsafe {
-        inkwell::llvm_sys::support::LLVMParseCommandLineOptions(
-            argv.len() as i32,
-            argv.as_ptr(),
-            overview.as_ptr(),
-        );
-    }
+        inkwell::support::enable_llvm_pretty_stack_trace();
 
-    inkwell::support::enable_llvm_pretty_stack_trace();
-
-    match target {
-        PolkaVMTarget::PVM => inkwell::targets::Target::initialize_riscv(&Default::default()),
-    }
+        match target {
+            PolkaVMTarget::PVM => inkwell::targets::Target::initialize_riscv(&Default::default()),
+        }
+    });
 }

--- a/crates/llvm-context/src/optimizer/settings/mod.rs
+++ b/crates/llvm-context/src/optimizer/settings/mod.rs
@@ -18,6 +18,10 @@ pub struct Settings {
     pub level_middle_end_size: SizeLevel,
     /// The back-end optimization level.
     pub level_back_end: inkwell::OptimizationLevel,
+    /// Whether to target the wide integer instructions.
+    /// `i256` becomes a machine type held in its own registers,
+    /// so each 256-bit operation selects to one instruction.
+    pub wide_instructions: bool,
 
     /// Whether the LLVM `verify each` option is enabled.
     pub is_verify_each_enabled: bool,
@@ -36,6 +40,7 @@ impl Settings {
             level_middle_end,
             level_middle_end_size,
             level_back_end,
+            wide_instructions: false,
 
             is_verify_each_enabled: false,
             is_debug_logging_enabled: false,
@@ -55,6 +60,7 @@ impl Settings {
             level_middle_end,
             level_middle_end_size,
             level_back_end,
+            wide_instructions: false,
 
             is_verify_each_enabled,
             is_debug_logging_enabled,
@@ -181,6 +187,7 @@ impl PartialEq for Settings {
         self.level_middle_end == other.level_middle_end
             && self.level_middle_end_size == other.level_middle_end_size
             && self.level_back_end == other.level_back_end
+            && self.wide_instructions == other.wide_instructions
     }
 }
 
@@ -188,9 +195,10 @@ impl std::fmt::Display for Settings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "M{}B{}",
+            "M{}B{}{}",
             self.middle_end_as_string(),
             self.level_back_end as u8,
+            if self.wide_instructions { "W" } else { "" },
         )
     }
 }

--- a/crates/llvm-context/src/optimizer/settings/mod.rs
+++ b/crates/llvm-context/src/optimizer/settings/mod.rs
@@ -67,9 +67,10 @@ impl Settings {
         }
     }
 
-    /// Creates settings from a CLI optimization parameter.
-    pub fn try_from_cli(value: char) -> anyhow::Result<Self> {
-        Ok(match value {
+    /// Creates settings from a CLI optimization parameter and whether to target the wide
+    /// integer instructions.
+    pub fn try_from_cli(value: char, wide_instructions: bool) -> anyhow::Result<Self> {
+        let mut settings = match value {
             '0' => Self::none(),
             '1' => Self::new(
                 inkwell::OptimizationLevel::Less,
@@ -92,7 +93,10 @@ impl Settings {
             ),
             'z' => Self::size(),
             char => anyhow::bail!("Unexpected optimization option '{}'", char),
-        })
+        };
+        settings.wide_instructions = wide_instructions;
+
+        Ok(settings)
     }
 
     /// Returns the settings without optimizations.

--- a/crates/llvm-context/src/polkavm/context/function/llvm_runtime.rs
+++ b/crates/llvm-context/src/polkavm/context/function/llvm_runtime.rs
@@ -1,8 +1,11 @@
 //! The LLVM runtime functions.
 
+use std::num::NonZeroU32;
+
 use crate::optimizer::Optimizer;
-use crate::polkavm::context::function::declaration::Declaration as FunctionDeclaration;
-use crate::polkavm::context::function::Function;
+use crate::polkavm::context::function::{
+    declaration::Declaration as FunctionDeclaration, intrinsics::Intrinsics, Function,
+};
 
 /// The runtime functions, implemented on the LLVM side.
 /// The functions are automatically linked to the LLVM implementations if the signatures match.
@@ -31,8 +34,33 @@ impl<'ctx> LLVMRuntime<'ctx> {
     /// The corresponding runtime function name.
     pub const FUNCTION_SIGNEXTEND: &'static str = "__signextend";
 
+    /// The corresponding intrinsic name. Operands are `(augend, addend, modulus)`.
+    pub const INTRINSIC_ADDMOD: &'static str = "llvm.riscv.revive.addmod";
+
+    /// The corresponding intrinsic name. Operands are `(multiplier, multiplicand, modulus)`.
+    pub const INTRINSIC_MULMOD: &'static str = "llvm.riscv.revive.mulmod";
+
+    /// The corresponding intrinsic name. Operands are `(base, exponent)`.
+    pub const INTRINSIC_EXP: &'static str = "llvm.riscv.revive.exp";
+
+    /// The corresponding intrinsic name. Operands are `(byte_index, value)`.
+    pub const INTRINSIC_SIGNEXTEND: &'static str = "llvm.riscv.revive.signextend";
+
     /// A shortcut constructor.
     pub fn new(
+        llvm: &'ctx inkwell::context::Context,
+        module: &inkwell::module::Module<'ctx>,
+        optimizer: &Optimizer,
+    ) -> Self {
+        if optimizer.settings().wide_instructions {
+            Self::new_intrinsics(llvm, module)
+        } else {
+            Self::new_stdlib(llvm, module, optimizer)
+        }
+    }
+
+    /// Binds the `stdlib.ll` routines, which implement these operations in LLVM IR.
+    fn new_stdlib(
         llvm: &'ctx inkwell::context::Context,
         module: &inkwell::module::Module<'ctx>,
         optimizer: &Optimizer,
@@ -61,6 +89,50 @@ impl<'ctx> LLVMRuntime<'ctx> {
             mul_mod,
             exp,
             sign_extend,
+        }
+    }
+
+    /// Declares the custom intrinsics, each of which selects to a single instruction, and
+    /// demotes the `stdlib.ll` routines they replace so that global DCE can drop the bodies.
+    ///
+    /// The declarations carry no attributes of their own: LLVM applies the intrinsic's own
+    /// attribute set when the name resolves to an intrinsic ID, and `memory(none)` from that
+    /// set is what lets equal calls be merged and hoisted, exactly as `stdlib.ll`'s `readnone`
+    /// does on the other path.
+    fn new_intrinsics(
+        llvm: &'ctx inkwell::context::Context,
+        module: &inkwell::module::Module<'ctx>,
+    ) -> Self {
+        let word_type = llvm
+            .custom_width_int_type(
+                NonZeroU32::new(revive_common::BIT_LENGTH_WORD as u32).expect("const is non-zero"),
+            )
+            .expect("valid integer width");
+        let binary_type = word_type.fn_type(&[word_type.into(), word_type.into()], false);
+        let ternary_type = word_type.fn_type(
+            &[word_type.into(), word_type.into(), word_type.into()],
+            false,
+        );
+
+        // `stdlib.ll` gives these external linkage, which global DCE cannot remove. Demoting
+        // them is what lets the bodies go once the intrinsics replace every call.
+        for name in [
+            Self::FUNCTION_ADDMOD,
+            Self::FUNCTION_MULMOD,
+            Self::FUNCTION_EXP,
+            Self::FUNCTION_SIGNEXTEND,
+        ] {
+            module
+                .get_function(name)
+                .expect("should be declared in stdlib")
+                .set_linkage(inkwell::module::Linkage::Private);
+        }
+
+        Self {
+            add_mod: Intrinsics::declare(llvm, module, Self::INTRINSIC_ADDMOD, ternary_type),
+            mul_mod: Intrinsics::declare(llvm, module, Self::INTRINSIC_MULMOD, ternary_type),
+            exp: Intrinsics::declare(llvm, module, Self::INTRINSIC_EXP, binary_type),
+            sign_extend: Intrinsics::declare(llvm, module, Self::INTRINSIC_SIGNEXTEND, binary_type),
         }
     }
 

--- a/crates/llvm-context/src/polkavm/context/tests.rs
+++ b/crates/llvm-context/src/polkavm/context/tests.rs
@@ -150,3 +150,11 @@ pub fn check_attribute_min_size_mode_z() {
         .attributes(inkwell::attributes::AttributeLoc::Function)
         .contains(&llvm.create_enum_attribute(Attribute::MinSize as u32, 0)));
 }
+
+#[test]
+pub fn custom_wide_instruction_intrinsics_exist() {
+    assert!(
+        inkwell::intrinsics::Intrinsic::find("llvm.riscv.revive.mulmod").is_some(),
+        "the linked LLVM does not carry the custom wide instruction intrinsics"
+    );
+}

--- a/crates/llvm-context/src/polkavm/context/tests.rs
+++ b/crates/llvm-context/src/polkavm/context/tests.rs
@@ -1,8 +1,7 @@
 //! The LLVM IR generator context tests.
 
 use crate::optimizer::settings::Settings as OptimizerSettings;
-use crate::polkavm::context::attribute::Attribute;
-use crate::polkavm::context::Context;
+use crate::polkavm::context::{attribute::Attribute, function::llvm_runtime::LLVMRuntime, Context};
 use crate::PolkaVMTarget;
 
 /// Initializes the LLVM compiler backend.
@@ -156,5 +155,65 @@ pub fn custom_wide_instruction_intrinsics_exist() {
     assert!(
         inkwell::intrinsics::Intrinsic::find("llvm.riscv.revive.mulmod").is_some(),
         "the linked LLVM does not carry the custom wide instruction intrinsics"
+    );
+}
+
+/// The wide setting swaps the modular arithmetic helpers for intrinsics and makes the routines
+/// they replace reclaimable. `stdlib.ll` gives these external linkage, and global DCE cannot
+/// drop an externally visible symbol, so without the demotion they would survive in every emitted object.
+#[test]
+pub fn custom_wide_instructions_replace_the_stdlib_modular_arithmetic() {
+    initialize_llvm();
+
+    let llvm = inkwell::context::Context::create();
+    let mut settings = OptimizerSettings::size();
+    settings.wide_instructions = true;
+    let context = Context::new_dummy(&llvm, settings);
+
+    assert_eq!(
+        context
+            .llvm_runtime()
+            .mul_mod
+            .value
+            .get_name()
+            .to_str()
+            .expect("should get the intrinsic name"),
+        LLVMRuntime::INTRINSIC_MULMOD,
+    );
+    assert_eq!(
+        context
+            .module()
+            .get_function(LLVMRuntime::FUNCTION_MULMOD)
+            .expect("stdlib is linked into every module")
+            .get_linkage(),
+        inkwell::module::Linkage::Private,
+    );
+}
+
+/// The default path still binds the stdlib routines, and still privatizes them.
+#[test]
+pub fn default_settings_keep_the_stdlib_modular_arithmetic() {
+    initialize_llvm();
+
+    let llvm = inkwell::context::Context::create();
+    let context = Context::new_dummy(&llvm, OptimizerSettings::size());
+
+    assert_eq!(
+        context
+            .llvm_runtime()
+            .mul_mod
+            .value
+            .get_name()
+            .to_str()
+            .expect("should get the function name"),
+        LLVMRuntime::FUNCTION_MULMOD,
+    );
+    assert_eq!(
+        context
+            .module()
+            .get_function(LLVMRuntime::FUNCTION_MULMOD)
+            .expect("stdlib is linked into every module")
+            .get_linkage(),
+        inkwell::module::Linkage::Private,
     );
 }

--- a/crates/llvm-context/src/target_machine/mod.rs
+++ b/crates/llvm-context/src/target_machine/mod.rs
@@ -39,6 +39,16 @@ impl TargetMachine {
     /// was not isolated, so the feature is restricted to the path it was validated against.
     pub const VM_FEATURE_UNALIGNED: &'static str = ",+unaligned-scalar-mem";
 
+    /// RISC-V backend extension making `i256` a machine type held in its own registers, so that
+    /// each 256-bit operation selects to a single instruction instead of a chain of four 64-bit
+    /// limbs, and wide arguments and return values travel in registers rather than through
+    /// memory. Selected per module by explicitly enabling wide instructions.
+    ///
+    /// It implies the vector extensions, because the registers it uses are RVV's. Enabling it
+    /// therefore also advertises a vector unit to the middle end, which is why it must not be
+    /// enabled for code that has no 256-bit values to gain from it.
+    pub const VM_FEATURE_WIDE: &'static str = ",+xrevivevec";
+
     /// A shortcut constructor.
     /// A separate instance for every optimization level is created.
     ///
@@ -49,11 +59,20 @@ impl TargetMachine {
         optimizer_settings: &OptimizerSettings,
         unaligned_scalar_mem: bool,
     ) -> anyhow::Result<Self> {
-        let features = if unaligned_scalar_mem {
-            format!("{}{}", Self::VM_FEATURES, Self::VM_FEATURE_UNALIGNED)
-        } else {
-            Self::VM_FEATURES.to_string()
-        };
+        let features = format!(
+            "{}{}{}",
+            Self::VM_FEATURES,
+            if unaligned_scalar_mem {
+                Self::VM_FEATURE_UNALIGNED
+            } else {
+                ""
+            },
+            if optimizer_settings.wide_instructions {
+                Self::VM_FEATURE_WIDE
+            } else {
+                ""
+            },
+        );
         let target_machine = inkwell::targets::Target::from_name(target.name())
             .ok_or_else(|| anyhow::anyhow!("LLVM target machine `{}` not found", target.name()))?
             .create_target_machine(
@@ -130,5 +149,61 @@ impl TargetMachine {
     /// Returns the target data.
     pub fn get_target_data(&self) -> inkwell::targets::TargetData {
         self.target_machine.get_target_data()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Target, TargetMachine};
+    use crate::optimizer::settings::Settings as OptimizerSettings;
+
+    /// This asserts plumbing only, not LLVM: `get_feature_string` returns the string
+    /// it was given verbatim, so a feature name LLVM does not recognize round-trips
+    /// unchanged and is only warned about on stderr.
+    #[test]
+    fn custom_wide_instructions_setting_appends_the_target_feature() {
+        crate::initialize_llvm(
+            Target::PVM,
+            "resolc",
+            crate::OptimizerSettingsSizeLevel::Zero,
+            false,
+            Default::default(),
+        );
+
+        fn assert_feature_matches_setting(features: &str, feature: &str, enabled: bool) {
+            let has_feature = features.contains(feature);
+            assert!(
+                has_feature == enabled,
+                "`{feature}` is {}, but its setting was {}. Feature string: `{features}`",
+                if has_feature { "included" } else { "excluded" },
+                if enabled { "enabled" } else { "disabled" },
+            );
+        }
+
+        // Each feature must appear exactly when its own flag is set.
+        for enable_wide_instructions in [false, true] {
+            for enable_unaligned_scalar_mem in [false, true] {
+                let mut settings = OptimizerSettings::size();
+                settings.wide_instructions = enable_wide_instructions;
+                let features =
+                    TargetMachine::new(Target::PVM, &settings, enable_unaligned_scalar_mem)
+                        .expect("the target machine should be created")
+                        .target_machine
+                        .get_feature_string()
+                        .to_string_lossy()
+                        .into_owned();
+
+                assert_feature_matches_setting(
+                    &features,
+                    TargetMachine::VM_FEATURE_WIDE,
+                    enable_wide_instructions,
+                );
+                assert_feature_matches_setting(
+                    &features,
+                    TargetMachine::VM_FEATURE_UNALIGNED,
+                    enable_unaligned_scalar_mem,
+                );
+            }
+        }
     }
 }

--- a/crates/resolc/src/lib.rs
+++ b/crates/resolc/src/lib.rs
@@ -224,7 +224,14 @@ pub fn standard_json<T: Compiler>(
     let prune_output = solc_input.settings.selection_to_prune();
     let deployed_libraries = solc_input.settings.libraries.as_paths();
     let linker_symbols = solc_input.settings.libraries.as_linker_symbols()?;
-    let optimizer_settings = OptimizerSettings::try_from_cli(solc_input.settings.optimizer.mode)?;
+    let optimizer_settings = OptimizerSettings::try_from_cli(
+        solc_input.settings.optimizer.mode,
+        solc_input
+            .settings
+            .polkavm
+            .wide_instructions
+            .unwrap_or(false),
+    )?;
     let detect_missing_libraries =
         solc_input.settings.detect_missing_libraries || detect_missing_libraries;
     let use_newyork = use_newyork || solc_input.settings.polkavm.newyork.unwrap_or(false);

--- a/crates/resolc/src/resolc/arguments.rs
+++ b/crates/resolc/src/resolc/arguments.rs
@@ -72,6 +72,13 @@ pub struct Arguments {
     #[arg(long = "newyork")]
     pub newyork: bool,
 
+    /// Use the wide integer instructions, which make contract code considerably smaller.
+    ///
+    /// In standard JSON mode this flag is rejected; enable it via the `settings.polkavm.wideInstructions`
+    /// input field instead. Off by default.
+    #[arg(long = "wide-instructions")]
+    pub wide_instructions: bool,
+
     /// Disable the `solc` optimizer.
     /// Use it if your project uses the `MSIZE` instruction, or in other cases.
     /// Beware that it will prevent libraries from being inlined.
@@ -413,6 +420,13 @@ impl Arguments {
             if self.newyork {
                 messages.push(SolcStandardJsonOutputError::new_error(
                     "The newyork IR pipeline must be enabled in standard JSON input polkavm settings.",
+                    None,
+                    None,
+                ));
+            }
+            if self.wide_instructions {
+                messages.push(SolcStandardJsonOutputError::new_error(
+                    "The wide instructions must be enabled in standard JSON input polkavm settings.",
                     None,
                     None,
                 ));

--- a/crates/resolc/src/resolc/main.rs
+++ b/crates/resolc/src/resolc/main.rs
@@ -126,7 +126,8 @@ fn main_inner(
         }
     }
 
-    let mut optimizer_settings = OptimizerSettings::try_from_cli(arguments.optimization)?;
+    let mut optimizer_settings =
+        OptimizerSettings::try_from_cli(arguments.optimization, arguments.wide_instructions)?;
     optimizer_settings.is_verify_each_enabled = arguments.llvm_verify_each;
     optimizer_settings.is_debug_logging_enabled = arguments.llvm_debug_logging;
 

--- a/crates/resolc/src/test_utils.rs
+++ b/crates/resolc/src/test_utils.rs
@@ -317,7 +317,8 @@ pub fn build_yul_standard_json(
 ) -> anyhow::Result<SolcStandardJsonOutput> {
     check_dependencies();
     inkwell::support::enable_llvm_pretty_stack_trace();
-    let optimizer_settings = OptimizerSettings::try_from_cli(solc_input.settings.optimizer.mode)?;
+    let optimizer_settings =
+        OptimizerSettings::try_from_cli(solc_input.settings.optimizer.mode, false)?;
     initialize_llvm(
         PolkaVMTarget::PVM,
         crate::DEFAULT_EXECUTABLE_NAME,

--- a/crates/runtime-api/build.rs
+++ b/crates/runtime-api/build.rs
@@ -24,6 +24,9 @@ const TARGET_ABI_FLAG: &str = "-mabi=lp64e";
 /// a subset of the caller's, so a helper carrying `+unaligned-scalar-mem`
 /// would fail to inline into stock-path code. The feature does not change the
 /// helpers' own codegen, so omitting it costs nothing.
+/// `+xrevivevec` is omitted for the same reason, and because it implies the
+/// vector extensions: these helpers hold no 256-bit values, but at `-O3` the
+/// loop vectorizer would still rewrite `memcpy` and `memmove` into vector code.
 const TARGET_FEATURES: &[&str] = &[
     "+e",
     "+m",

--- a/crates/solc-json-interface/src/standard_json/input/settings/polkavm/mod.rs
+++ b/crates/solc-json-interface/src/standard_json/input/settings/polkavm/mod.rs
@@ -20,6 +20,9 @@ pub struct PolkaVM {
     /// Route Yul lowering through the experimental newyork IR pipeline. Off by default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub newyork: Option<bool>,
+    /// Target the wide integer instructions. Off by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wide_instructions: Option<bool>,
 }
 
 impl PolkaVM {
@@ -28,6 +31,7 @@ impl PolkaVM {
             memory_config,
             debug_information: Some(debug_information),
             newyork: None,
+            wide_instructions: None,
         }
     }
 }


### PR DESCRIPTION
## Description

Allows `resolc` to target our new RISC-V vendor extension, which makes `i256` a machine type held in its own registers: each 256-bit operation selects to a single instruction instead of a chain of four 64-bit limbs, and `addmod`, `mulmod`, `exp` and `signextend` become emitted intrinsics instead of `stdlib.ll` routines.

The extension is available via the now-updated LLVM submodule, using our fork (currently `kvpanch/vec_ext_custom_inst` @ `355e253`).

> [!NOTE]
> **CLI flag:**
>
> A CLI flag (`--wide-instructions`) and JSON input (`settings.polkavm.wideInstructions`) are implemented as part of this change to make the feature more easily measurable with and without the custom instructions enabled during development.
>
> (With the flag on, compilation fails at the PolkaVM linker, since this does not include a polkavm update including the decoding. Everything up to the ELF object runs: the intrinsics reach the IR, the `stdlib.ll` bodies are gone from the optimized module, and the object disassembles to real `revive.*` instructions.)

## Follow-up note: newyork optimizer narrowing

The newyork IR pipeline currently narrows aggressively because a wide operation used to be a four-limb chain. With the extension, narrowing to a scalar vs keeping a value in a 256-bit register likely needs the cost/benefit calculations to be remeasured.