### PR TITLE
yul: Compile objects that carry deploy code only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Supported `polkadot-sdk` rev: `2604.2.0`
 
 ### Fixed
 - `--newyork`: A bug in dead call value analysis. [#589](https://github.com/paritytech/revive/pull/589)
+- Yul objects carrying deploy code only, without a `_deployed` runtime sub-object, failed to compile with an LLVM IR verification error. [#PR](https://github.com/paritytech/revive/pull/PR)
 
 ## v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Supported `polkadot-sdk` rev: `2604.2.0`
 
 ### Fixed
 - `--newyork`: A bug in dead call value analysis. [#589](https://github.com/paritytech/revive/pull/589)
-- Yul objects carrying deploy code only, without a `_deployed` runtime sub-object, failed to compile with an LLVM IR verification error. [#PR](https://github.com/paritytech/revive/pull/PR)
+- Yul objects carrying deploy code only, without a `_deployed` runtime sub-object, failed to compile with an LLVM IR verification error. [#597](https://github.com/paritytech/revive/pull/597)
 
 ## v1.4.0
 

--- a/crates/resolc/src/cli_utils.rs
+++ b/crates/resolc/src/cli_utils.rs
@@ -34,6 +34,8 @@ pub const YUL_DUPLICATE_FUNCTIONS_SWITCH_PATH: &str =
 /// Yul contract with duplicate function names in deeply nested switch cases.
 pub const YUL_DUPLICATE_FUNCTIONS_DEEP_NESTING_PATH: &str =
     "src/tests/data/yul/duplicate_functions_deep_nesting.yul";
+/// Yul contract carrying deploy code only, without the `_deployed` runtime sub-object.
+pub const YUL_DEPLOY_ONLY_OBJECT_PATH: &str = "src/tests/data/yul/deploy_only_object.yul";
 
 /// The standard JSON contracts test fixture path.
 pub const STANDARD_JSON_CONTRACTS_PATH: &str =

--- a/crates/resolc/src/tests/cli/yul.rs
+++ b/crates/resolc/src/tests/cli/yul.rs
@@ -2,7 +2,7 @@
 
 use crate::cli_utils::{
     assert_command_failure, assert_command_success, assert_equal_exit_codes, execute_resolc,
-    execute_solc, RESOLC_YUL_FLAG, SOLC_YUL_FLAG, YUL_CONTRACT_PATH,
+    execute_solc, RESOLC_YUL_FLAG, SOLC_YUL_FLAG, YUL_CONTRACT_PATH, YUL_DEPLOY_ONLY_OBJECT_PATH,
     YUL_DUPLICATE_FUNCTIONS_DEEP_NESTING_PATH, YUL_DUPLICATE_FUNCTIONS_SWITCH_PATH,
     YUL_INVALID_HEX_NIBBLES_PATH,
 };
@@ -62,4 +62,17 @@ fn duplicate_functions_deep_nesting() {
         &resolc_result,
         "Duplicate function names in deeply nested switch cases",
     );
+}
+
+#[test]
+fn compiles_object_without_a_runtime_sub_object() {
+    let resolc_result = execute_resolc(&[YUL_DEPLOY_ONLY_OBJECT_PATH, RESOLC_YUL_FLAG, "--bin"]);
+    assert_command_success(
+        &resolc_result,
+        "An object carrying deploy code only, without a `_deployed` sub-object",
+    );
+
+    // `solc` accepts this too, which is the whole point: the two front-ends should agree.
+    let solc_result = execute_solc(&[YUL_DEPLOY_ONLY_OBJECT_PATH, SOLC_YUL_FLAG]);
+    assert_equal_exit_codes(&solc_result, &resolc_result);
 }

--- a/crates/resolc/src/tests/data/yul/deploy_only_object.yul
+++ b/crates/resolc/src/tests/data/yul/deploy_only_object.yul
@@ -1,0 +1,8 @@
+object "DeployOnly" {
+    code {
+        {
+            mstore(0, 42)
+            return(0, 32)
+        }
+    }
+}

--- a/crates/yul/src/parser/statement/object.rs
+++ b/crates/yul/src/parser/statement/object.rs
@@ -20,7 +20,12 @@ use crate::lexer::token::location::Location;
 use crate::lexer::token::Token;
 use crate::lexer::Lexer;
 use crate::parser::error::Error as ParserError;
+use crate::parser::statement::block::Block;
 use crate::parser::statement::code::Code;
+use crate::parser::statement::expression::function_call::name::Name;
+use crate::parser::statement::expression::function_call::FunctionCall;
+use crate::parser::statement::expression::Expression;
+use crate::parser::statement::Statement;
 use crate::visitor::AstNode;
 use crate::visitor::AstVisitor;
 
@@ -117,7 +122,7 @@ impl Object {
                     factory_dependencies.extend(object.factory_dependencies.drain());
                     Some(Box::new(object))
                 }
-                _ => None,
+                _ => Some(Box::new(Self::implicit_runtime_code(&identifier, location))),
             };
 
             if let Token {
@@ -171,6 +176,43 @@ impl Object {
             inner_object,
             factory_dependencies,
         })
+    }
+
+    /// Builds the runtime code object for a deploy-only object, that is one the source omitted
+    /// the `_deployed` sub-object for.
+    ///
+    /// Such an object carries deploy code only, so the deployed contract has no runtime code to
+    /// run. `solc` accepts this, and the EVM behaviour of "no runtime code" is a successful
+    /// return with empty data, which is exactly what an empty Yul code block lowers to (see
+    /// `Code::into_llvm`, which terminates every code block with an implicit `stop`).
+    ///
+    /// Materializing the sub-object here instead of special casing its absence in code
+    /// generation keeps every consumer of the AST -- both IR pipelines, the visitors and the
+    /// analyses -- on the one path they already handle.
+    ///
+    /// The body is an explicit `stop` rather than an empty block. The two are equivalent, but an
+    /// empty runtime block currently trips an assertion in `polkavm-linker` when lowered through
+    /// the `--newyork` pipeline.
+    fn implicit_runtime_code(identifier: &str, location: Location) -> Self {
+        let stop = Statement::Expression(Expression::FunctionCall(FunctionCall {
+            location,
+            name: Name::Stop,
+            arguments: vec![],
+        }));
+
+        Self {
+            location,
+            identifier: format!("{identifier}_deployed"),
+            code: Code {
+                location,
+                block: Block {
+                    location,
+                    statements: vec![stop],
+                },
+            },
+            inner_object: None,
+            factory_dependencies: HashSet::new(),
+        }
     }
 
     /// Get the list of missing deployable libraries.
@@ -327,7 +369,10 @@ mod tests {
     use crate::lexer::token::location::Location;
     use crate::lexer::Lexer;
     use crate::parser::error::Error;
+    use crate::parser::statement::expression::function_call::name::Name;
+    use crate::parser::statement::expression::Expression;
     use crate::parser::statement::object::Object;
+    use crate::parser::statement::Statement;
 
     #[test]
     fn error_invalid_token_object() {
@@ -487,5 +532,72 @@ object "Test" {
             }
             .into())
         );
+    }
+    #[test]
+    fn deploy_only_object_gets_an_implicit_runtime_object() {
+        let input = r#"
+object "Test" {
+    code {
+        { mstore(0, 42) return(0, 32) }
+    }
+}
+    "#;
+
+        let mut lexer = Lexer::new(input.to_owned());
+        let object = Object::parse(&mut lexer, None).expect("the object should parse");
+
+        let inner = object
+            .inner_object
+            .expect("a deploy-only object should get an implicit runtime object");
+        assert_eq!(inner.identifier, "Test_deployed");
+        assert_eq!(inner.inner_object, None);
+
+        // An explicit `stop`, so that `__runtime` is emitted with a terminator.
+        assert_eq!(inner.code.block.statements.len(), 1);
+        match &inner.code.block.statements[0] {
+            Statement::Expression(Expression::FunctionCall(call)) => {
+                assert_eq!(call.name, Name::Stop);
+                assert!(call.arguments.is_empty());
+            }
+            statement => panic!("expected a `stop()` call, found {statement:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_runtime_object_is_preserved() {
+        let input = r#"
+object "Test" {
+    code {
+        { mstore(0, 42) return(0, 32) }
+    }
+    object "Test_deployed" {
+        code {
+            { invalid() }
+        }
+    }
+}
+    "#;
+
+        let mut lexer = Lexer::new(input.to_owned());
+        let object = Object::parse(&mut lexer, None).expect("the object should parse");
+
+        let inner = object
+            .inner_object
+            .expect("the runtime object is present in the source");
+        assert_eq!(inner.identifier, "Test_deployed");
+
+        // The source body must survive rather than be replaced by the implicit one. Yul wraps a
+        // code body in its own block, hence the extra level.
+        assert_eq!(inner.code.block.statements.len(), 1);
+        let body = match &inner.code.block.statements[0] {
+            Statement::Block(block) => block,
+            statement => panic!("expected the code body block, found {statement:?}"),
+        };
+        match &body.statements[0] {
+            Statement::Expression(Expression::FunctionCall(call)) => {
+                assert_eq!(call.name, Name::Invalid);
+            }
+            statement => panic!("expected an `invalid()` call, found {statement:?}"),
+        }
     }
 }


### PR DESCRIPTION
# Description

Closes #490

`resolc --yul` rejected any Yul object that carries deploy code only, that is one without a `_deployed` runtime sub-object, while `solc` compiles it:

```yul
object "Test" {
    code {
        { mstore(0, 42) return(0, 32) }
    }
}
```

```
Error: The contract `deploy_only.yul:Test` unoptimized LLVM IR verification error:
Basic Block in function '__runtime' does not have terminator!
label %entry
```

## Cause

`Object::declare` declares `PolkaVMRuntimeCodeFunction` unconditionally, so `__runtime` always exists with an empty `entry` block. `Object::into_llvm` only ever *defines* it from the `_deployed` branch, which is reached through `if let Some(object) = self.inner_object`. With no sub-object the function stays declared and undefined, and the module fails verification.

Not declaring it is not an option: `Entry::leave_entry` looks `__runtime` up and bails with `Contract runtime code not found`, since `__entry` dispatches to either `__deploy` or `__runtime` on the call flag.

## Fix

`Object::parse` now materializes the runtime sub-object when the source omits it, so the AST that reaches code generation always has one.

Doing it in the parser rather than special casing the absence in code generation keeps every consumer on the path it already handles. That matters here because both IR pipelines read this field: `newyork`'s `YulTranslator::translate_object` has the same `if let Some(inner_object)` shape, and `--newyork` reproduces the identical error. One parser-level change fixes both.

The synthesized body is an explicit `stop()`. `Code::into_llvm` terminates every code block with an implicit `stop` anyway ("The EVM lets the code return implicitly"), so this is exactly what an empty runtime block lowers to, and it matches the EVM behaviour of calling an account with no code: success with empty return data.

I did not use an empty block, for two reasons. It would leave `__runtime` as `entry: br %return` / `return: unreachable`, and that `unreachable` is now *reachable* rather than a dead tail, which is UB the optimizer is free to exploit — `__runtime` is `Private` and called only from `__entry`, so folding it away could turn a call into a constructor run. And separately, an empty runtime block currently trips an assertion in `polkavm-linker` under `--newyork` (see below), which the `stop()` avoids.

Tests added:
- `revive-yul`: the deploy-only object gets the implicit runtime object with a `stop()` body, and an explicit `_deployed` object is not clobbered by it.
- `resolc`: `compiles_object_without_a_runtime_sub_object` compiles the new `deploy_only_object.yul` fixture end to end and cross-checks that `solc` agrees on the exit code, which is the premise of the issue.