### PR TITLE
newyork: Terminate object code with the implicit EVM return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Supported `polkadot-sdk` rev: `2604.2.0`
 
 ### Fixed
 - `--newyork`: A bug in dead call value analysis. [#589](https://github.com/paritytech/revive/pull/589)
-- `--newyork`: Object code that fell off the end was not terminated with the implicit EVM return, so LLVM folded away the runtime dispatch and a call would have run the constructor. [#PR](https://github.com/paritytech/revive/pull/PR)
+- `--newyork`: Object code that fell off the end was not terminated with the implicit EVM return, so LLVM folded away the runtime dispatch and a call would have run the constructor. [#598](https://github.com/paritytech/revive/pull/598)
 
 ## v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Supported `polkadot-sdk` rev: `2604.2.0`
 
 ### Fixed
 - `--newyork`: A bug in dead call value analysis. [#589](https://github.com/paritytech/revive/pull/589)
+- `--newyork`: Object code that fell off the end was not terminated with the implicit EVM return, so LLVM folded away the runtime dispatch and a call would have run the constructor. [#PR](https://github.com/paritytech/revive/pull/PR)
 
 ## v1.4.0
 

--- a/crates/newyork/src/to_llvm.rs
+++ b/crates/newyork/src/to_llvm.rs
@@ -3496,6 +3496,14 @@ impl<'ctx> LlvmCodegen<'ctx> {
 
         self.generate_block(&object.code, context)?;
 
+        // The EVM lets the code return implicitly, so terminate the block the way the legacy
+        // pipeline does in `Code::into_llvm`. Without it a code block that falls off the end
+        // reaches the function's `ret void`, which contradicts `__entry` being `noreturn`: LLVM
+        // then proves the dispatch edge into this function unreachable and folds it away, so
+        // calling the deployed contract would run the constructor.
+        revive_llvm_context::polkavm_evm_return::stop(context)
+            .map_err(|error| CodegenError::Llvm(error.to_string()))?;
+
         context
             .set_debug_location(0, 0, None)
             .map_err(|error| CodegenError::Llvm(error.to_string()))?;

--- a/crates/resolc/src/cli_utils.rs
+++ b/crates/resolc/src/cli_utils.rs
@@ -34,6 +34,8 @@ pub const YUL_DUPLICATE_FUNCTIONS_SWITCH_PATH: &str =
 /// Yul contract with duplicate function names in deeply nested switch cases.
 pub const YUL_DUPLICATE_FUNCTIONS_DEEP_NESTING_PATH: &str =
     "src/tests/data/yul/duplicate_functions_deep_nesting.yul";
+/// Yul contract whose `_deployed` runtime object has an empty code block.
+pub const YUL_EMPTY_RUNTIME_OBJECT_PATH: &str = "src/tests/data/yul/empty_runtime_object.yul";
 
 /// The standard JSON contracts test fixture path.
 pub const STANDARD_JSON_CONTRACTS_PATH: &str =

--- a/crates/resolc/src/tests/cli/bin.rs
+++ b/crates/resolc/src/tests/cli/bin.rs
@@ -5,7 +5,7 @@ use crate::{
         absolute_path, assert_command_success, execute_command, execute_resolc, CommandResult,
         ResolcOptSettings, SolcOptSettings, SOLIDITY_CONTRACT_PATH,
         SOLIDITY_FOLDED_GUARD_INLINED_LOOP_PATH, STANDARD_JSON_CONTRACTS_PATH,
-        YUL_MEMSET_CONTRACT_PATH,
+        YUL_EMPTY_RUNTIME_OBJECT_PATH, YUL_MEMSET_CONTRACT_PATH,
     },
     SolcCompiler,
 };
@@ -175,6 +175,20 @@ fn compiles_yul_to_binary_blob() {
 fn compiles_newyork_folded_guard_inlined_loop() {
     let path = absolute_path(SOLIDITY_FOLDED_GUARD_INLINED_LOOP_PATH);
     let arguments = &[&path, "--newyork", "--disable-solc-optimizer", "--bin"];
+
+    let result = execute_resolc(arguments);
+    assert_pvm_blob(&result);
+}
+
+/// Compile regression: a `_deployed` object with an empty code block crashed the newyork
+/// pipeline in `polkavm-linker` with "inconsistent reachability after optimization". The code
+/// block fell through to the function's `ret void`, which contradicts `__entry` being
+/// `noreturn`, so LLVM folded the runtime dispatch edge away and a call would have run the
+/// constructor. The implicit `stop` the legacy pipeline appends keeps the edge live.
+#[test]
+fn compiles_newyork_empty_runtime_object() {
+    let path = absolute_path(YUL_EMPTY_RUNTIME_OBJECT_PATH);
+    let arguments = &[&path, "--yul", "--newyork", "--bin"];
 
     let result = execute_resolc(arguments);
     assert_pvm_blob(&result);

--- a/crates/resolc/src/tests/data/yul/empty_runtime_object.yul
+++ b/crates/resolc/src/tests/data/yul/empty_runtime_object.yul
@@ -1,0 +1,13 @@
+object "EmptyRuntime" {
+    code {
+        {
+            stop()
+        }
+    }
+
+    object "EmptyRuntime_deployed" {
+        code {
+            { }
+        }
+    }
+}


### PR DESCRIPTION
# Description

`--newyork` crashes in the linker on a Yul object whose `_deployed` runtime code block is empty:

```yul
object "T" {
    code { stop() }
    object "T_deployed" {
        code { }
    }
}
```

```
thread 'main' panicked at polkavm-linker-0.35.0/src/program_from_elf.rs:10396:
internal error: inconsistent reachability after optimization; this is a bug, please report it!
```

The default pipeline compiles the same input fine.

## Cause

The panic is fallout. The actual problem is a silent miscompile one step earlier.

`Code::into_llvm` in the legacy pipeline terminates every code block with an implicit `stop`
("The EVM lets the code return implicitly"). `LlvmCodegen::generate_object` in `newyork` does not,
so a block that falls off the end reaches the

```llvm
define private void @__runtime() {
entry:
  br label %return
return:
  ret void        ; <-- __runtime returns
}
```

`__entry` is marked `NoReturn` and puts `unreatwo calls. A `__runtime`
that returns therefore makes the `is_deploy ==d LLVM removes the
dispatch entirely:

```llvm
define void @__entry(i1 %0) {
entry:
  tail call fastcc void @__deploy()
  unreachable
}
```

Calling the deployed contract would run the **constructor**. The linker then sees exports whose
reachability no longer agrees and asserts.

## Fix

Append the implicit EVM return in `generate_obcy pipeline does. The
runtime function then ends in the exit syscall and keeps its `noreturn` shape, so the dispatch
edge stays live:

```llvm
define private void @__runtime() {
entry:
  call void @__revive_exit(i32 0, i256 0, i256 0)
  br label %return
return:
  ret void        ; now unreachable, cleaned up by LLVM
}
```

```llvm
define void @__entry(i1 %0) {
entry:
  br i1 %0, label %deploy_code_call_block, label %runtime_code_call_block
  ...
}
```

## Verification

| input | default | `--newyork` before | `--newyork` after |
| --- | --- | --- | --- |
| `_deployed` with an empty block | ✅ | 💥 linker assert | ✅ |
| `_deployed` with `stop()` | ✅ | ✅ | ✅ |

Across `crates/integration/contracts/*.sol`:

- **default pipeline: 83/83 byte-identical**, as expected since this only touches `newyork`.
- **`--newyork`: 82/83 byte-identical.** The ostruct.sol`, and it changes
  in the right direction. `selfdestruct` lowers to a `terminate` call that neither terminates the
  basic block nor is marked `noreturn`, so itsfall through and return
  into `__entry`'s `unreachable`. It now ends peline already ends it:

  ```llvm
    call void @terminate(...)
    call void @seal_return(i32 0, i32 ptrtoint2), i32 0)
    unreachable
  ```

  So the diff is `newyork` converging onto the which is the point of the
  change.

Test added: `compiles_newyork_empty_runtime_obpty_runtime_object.yul`
fixture through `--yul --newyork --bin`, mirroring the existing
`compiles_newyork_folded_guard_inlined_loop` r

`cargo test -p revive-newyork` 92 passed, `cargo test -p resolc --lib` 69 passed, clippy clean.

## Note

Found while working on #490, but independent of it: #490 is an object with **no** `_deployed` sub-object at all, which fails in both pipelines with an LLVM verifier error. This one is an object **with** a `_deployed` sub-object whoseaffects `--newyork`. Neither fix depends on the other.