### PR TITLE
resolc: Report unsupported Yul object shapes instead of aborting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Supported `polkadot-sdk` rev: `2604.2.0`
 
 ### Fixed
 - `--newyork`: A bug in dead call value analysis. [#589](https://github.com/paritytech/revive/pull/589)
+- Yul objects that `resolc` cannot represent, a sibling object that is not a contract and the dotted notation for a nested object, aborted the compiler instead of being reported. [#PR](https://github.com/paritytech/revive/pull/PR)
 
 ## v1.4.0
 

--- a/crates/llvm-context/src/polkavm/evm/create.rs
+++ b/crates/llvm-context/src/polkavm/evm/create.rs
@@ -104,17 +104,7 @@ pub fn contract_hash<'ctx>(
 
     let parent = context.module().get_name().to_str().expect("Always valid");
 
-    let full_path = match context.yul() {
-        Some(yul_data) => yul_data
-            .resolve_path(
-                identifier
-                    .strip_suffix("_deployed")
-                    .unwrap_or(identifier.as_str()),
-            )
-            .expect("Always exists")
-            .to_owned(),
-        None => identifier.clone(),
-    };
+    let full_path = resolve_object_path(context, identifier.as_str())?;
 
     match code_type {
         CodeType::Deploy if full_path == parent => {
@@ -133,6 +123,36 @@ pub fn contract_hash<'ctx>(
         .map(Argument::value)
 }
 
+/// Resolves the object `identifier` a `dataoffset` or `datasize` refers to.
+///
+/// Every object `resolc` compiles is a contract, and each is keyed by its own identifier. Two Yul
+/// constructs therefore have no representation here and are reported instead of asserted on:
+/// sibling objects that are not contracts, and the dotted `outer.inner` notation for reaching a
+/// nested object, whose separator never appears in an identifier.
+fn resolve_object_path(context: &Context, identifier: &str) -> anyhow::Result<String> {
+    let Some(yul_data) = context.yul() else {
+        return Ok(identifier.to_owned());
+    };
+
+    let key = identifier.strip_suffix("_deployed").unwrap_or(identifier);
+    if let Some(path) = yul_data.resolve_path(key) {
+        return Ok(path.to_owned());
+    }
+
+    if key.contains('.') {
+        anyhow::bail!(
+            "the object `{identifier}` can not be resolved: `resolc` does not support the dotted \
+             notation for addressing a nested Yul object"
+        );
+    }
+
+    anyhow::bail!(
+        "the object `{identifier}` can not be resolved: `resolc` expects every Yul object to be a \
+         contract of its own, so an object referenced by `dataoffset` or `datasize` must be one of \
+         the compiled contracts"
+    )
+}
+
 /// Translates the deploy call header size instruction. the header consists of
 /// the hash of the bytecode of the contract whose instance is being created.
 /// Represents `datasize` in Yul and `PUSH #[$]` in the EVM legacy assembly.
@@ -146,16 +166,8 @@ pub fn header_size<'ctx>(
 
     let parent = context.module().get_name().to_str().expect("Always valid");
 
-    let full_path = match context.yul() {
-        Some(yul_data) => yul_data
-            .resolve_path(
-                identifier
-                    .strip_suffix("_deployed")
-                    .unwrap_or(identifier.as_str()),
-            )
-            .unwrap_or_else(|| panic!("ICE: {identifier} not found {yul_data:?}")),
-        None => identifier.as_str(),
-    };
+    let full_path = resolve_object_path(context, identifier.as_str())?;
+    let full_path = full_path.as_str();
 
     match code_type {
         CodeType::Deploy if full_path == parent => {

--- a/crates/resolc/src/cli_utils.rs
+++ b/crates/resolc/src/cli_utils.rs
@@ -34,6 +34,10 @@ pub const YUL_DUPLICATE_FUNCTIONS_SWITCH_PATH: &str =
 /// Yul contract with duplicate function names in deeply nested switch cases.
 pub const YUL_DUPLICATE_FUNCTIONS_DEEP_NESTING_PATH: &str =
     "src/tests/data/yul/duplicate_functions_deep_nesting.yul";
+/// Yul contract with a sibling object that is not a contract of its own.
+pub const YUL_SIBLING_OBJECTS_PATH: &str = "src/tests/data/yul/sibling_objects.yul";
+/// Yul contract addressing a nested object through the dotted notation.
+pub const YUL_DOTTED_OBJECT_PATH: &str = "src/tests/data/yul/dotted_object_path.yul";
 
 /// The standard JSON contracts test fixture path.
 pub const STANDARD_JSON_CONTRACTS_PATH: &str =

--- a/crates/resolc/src/project/mod.rs
+++ b/crates/resolc/src/project/mod.rs
@@ -86,15 +86,37 @@ impl Project {
 
         let results = iter
             .map(|(path, mut contract)| {
-                let factory_dependencies = contract
-                    .ir
-                    .drain_factory_dependencies()
+                // Every object `resolc` compiles is a contract of its own, so an object referenced
+                // by `dataoffset` or `datasize` has to be one of them. A sibling object that is
+                // not, or the dotted notation for a nested object, has no entry here and used to
+                // panic.
+                let dependencies = contract.ir.drain_factory_dependencies();
+                let unresolved = dependencies
+                    .iter()
+                    .filter(|identifier| !self.identifier_paths.contains_key(*identifier))
+                    .cloned()
+                    .collect::<Vec<String>>();
+                if !unresolved.is_empty() {
+                    let error = SolcStandardJsonOutputError::new_error(
+                        format!(
+                            "{path}: the object(s) `{}` referenced by `dataoffset` or `datasize` \
+                             are not compiled contracts. `resolc` expects every Yul object to be a \
+                             contract of its own; sibling objects that are not, and the dotted \
+                             notation for addressing a nested object, are not supported.",
+                            unresolved.join("`, `"),
+                        ),
+                        None,
+                        None,
+                    );
+                    return (path, Err(error));
+                }
+                let factory_dependencies = dependencies
                     .iter()
                     .map(|identifier| {
                         self.identifier_paths
                             .get(identifier)
                             .cloned()
-                            .expect("Always exists")
+                            .expect("checked above")
                     })
                     .collect();
                 let missing_libraries = contract.get_missing_libraries(&deployed_libraries);

--- a/crates/resolc/src/tests/cli/mod.rs
+++ b/crates/resolc/src/tests/cli/mod.rs
@@ -10,3 +10,4 @@ mod output_dir;
 mod standard_json;
 mod usage;
 mod yul;
+mod yul_objects;

--- a/crates/resolc/src/tests/cli/yul_objects.rs
+++ b/crates/resolc/src/tests/cli/yul_objects.rs
@@ -1,0 +1,49 @@
+//! The tests for Yul object shapes `resolc` does not support.
+//!
+//! `resolc` compiles every Yul object as a contract of its own, so two shapes `solc` accepts have
+//! no representation: a sibling object that is not a contract, and the dotted notation for
+//! addressing a nested object. Both used to abort the compiler; see
+//! [paritytech/revive#351](https://github.com/paritytech/revive/issues/351).
+
+use crate::cli_utils::{
+    absolute_path, assert_command_failure, execute_resolc, CommandResult, RESOLC_YUL_FLAG,
+    YUL_DOTTED_OBJECT_PATH, YUL_SIBLING_OBJECTS_PATH,
+};
+
+/// Asserts the command failed with a diagnostic rather than by aborting.
+#[track_caller]
+fn assert_reported_not_aborted(result: &CommandResult, description: &str) {
+    assert_command_failure(result, description);
+
+    let output = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        !output.contains("panicked") && !output.contains("ICE:"),
+        "{description} should be reported, not abort the compiler, got: {output}"
+    );
+}
+
+#[test]
+fn reports_a_sibling_object_that_is_not_a_contract() {
+    let path = absolute_path(YUL_SIBLING_OBJECTS_PATH);
+    let result = execute_resolc(&[&path, RESOLC_YUL_FLAG, "--bin"]);
+
+    assert_reported_not_aborted(&result, "A sibling object that is not a contract");
+    assert!(
+        result.stderr.contains("Error"),
+        "the object should be named in the diagnostic, got: {}",
+        result.stderr
+    );
+}
+
+#[test]
+fn reports_the_dotted_object_notation() {
+    let path = absolute_path(YUL_DOTTED_OBJECT_PATH);
+    let result = execute_resolc(&[&path, RESOLC_YUL_FLAG, "--bin"]);
+
+    assert_reported_not_aborted(&result, "The dotted notation for a nested object");
+    assert!(
+        result.stderr.contains("dotted"),
+        "the diagnostic should explain the unsupported notation, got: {}",
+        result.stderr
+    );
+}

--- a/crates/resolc/src/tests/data/yul/dotted_object_path.yul
+++ b/crates/resolc/src/tests/data/yul/dotted_object_path.yul
@@ -1,0 +1,17 @@
+object "Test" {
+    code {
+        let size := datasize("Test_deployed.Test")
+        datacopy(0, dataoffset("Test_deployed.Test"), size)
+        return(0, size)
+    }
+    object "Test_deployed" {
+        code {
+            stop()
+        }
+        object "Test" {
+            code {
+                revert(0, 0)
+            }
+        }
+    }
+}

--- a/crates/resolc/src/tests/data/yul/sibling_objects.yul
+++ b/crates/resolc/src/tests/data/yul/sibling_objects.yul
@@ -1,0 +1,11 @@
+object "Test" {
+    code {
+        stop()
+    }
+    object "Test_deployed" {
+        code {}
+    }
+    object "Error" {
+        code {}
+    }
+}


### PR DESCRIPTION
# Description

Refs #351

`resolc` compiles every Yul object as a contract of its own. Two shapes `solc` accepts therefore have no representation, and both aborted the compiler rather than being reported. The two reproducers from the SRLabs finding, verbatim:

```yul
object "Test" {
    code { stop() }
    object "Test_deployed" { code {} }
    object "Error" { code {} }
}
```

```
thread 'main' panicked at crates/resolc/src/project/mod.rs:97:30: Always exists
```

```yul
object "Test" {
    code {
        let size := datasize("Test_deployed.Test")
        datacopy(0, dataoffset("Test_deployed.Test"), size)
        return(0, size)
    }
    object "Test_deployed" {
        code { stop() }
        object "Test" { code { revert(0, 0) } }
    }
}
```

```
thread '<unnamed>' panicked at crates/llvm-context/src/polkavm/evm/create.rs:156:32: ICE: Test_deployed.Test not found YulData { identifier_paths: {"Test": "…:Test"} }
```

## Cause

An object referenced through `dataoffset` or `datasize` is looked up among the compiled contracts. A sibling object that is not one has no entry, and neither does a dotted `outer.inner` path, since the separator never appears in an identifier. Three sites asserted on the miss rather than reporting it:

- `Project::compile` resolving factory dependencies, `.expect("Always exists")`.
- `create.rs` translating `dataoffset`, `.expect("Always exists")`.
- `create.rs` translating `datasize`, `panic!("ICE: …")`.

The issue reports two failures; the third is the same lookup duplicated between the `dataoffset` and `datasize` translations, so it aborts on the same input by a different route.

## Fix

The two `create.rs` sites now share a `resolve_object_path` helper, and all three name the object and say which constraint it hit:

```
Error: sibling_objects.yul:Test: the object(s) `Error` referenced by `dataoffset` or `datasize` are not compiled contracts. `resolc` expects every Yul object to be a contract of its own; sibling objects that are not, and the dotted notation for addressing a nested object, are not supported.
```

```
Error: LLVM IR generator: the object `Test_deployed.Test` can not be resolved: `resolc` does not support the dotted notation for addressing a nested Yul object
```

## Scope

**This reports the limitations, it does not lift them.** Supporting sibling objects or dotted paths changes what `resolc` accepts, which seemed like your call rather than something to decide inside a crash fix. Hence `Refs` rather than `Closes`: close the issue if diagnostics are the wanted resolution, and I am happy to take on either shape as a follow-up if not.

The finding also notes that both discrepancies are [undocumented](https://contracts.polkadot.io/differences_to_eth). A compiler message that explains the constraint covers the half a developer hits in practice; adding them to that page is the other half and is not in this PR.

## Verification

- Two tests in `crates/resolc/src/tests/cli/yul_objects.rs`, one per shape. They assert the output contains neither `panicked` nor `ICE:`, which is the property that regressed, rather than pinning an exact message.
- All 83 `crates/integration/contracts/*.sol` fixtures compile to byte-identical bytecode against the `v1.4.0` release binary, and the five existing Yul fixtures still compile. Worth stating because the refactored lookup is on the path every contract with a `_deployed` sub-object takes, not only the unsupported shapes.
- `cargo test -p resolc --lib` 70 passed, clippy clean.