### PR TITLE
Clarify revive README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # revive
 
-Yul recompiler to LLVM, targetting RISC-V on [PolkaVM](https://github.com/koute/polkavm).
+Solidity compiler for Polkadot, targeting PolkaVM through `pallet-revive`.
 
 Check the [docs](https://paritytech.github.io/revive/) or visit [contracts.polkadot.io](https://docs.polkadot.com/develop/smart-contracts/) to learn more about `revive` and contracts on Polkadot!
 


### PR DESCRIPTION
Updates the README opening to describe revive more clearly as the Solidity compiler for Polkadot targeting PolkaVM through pallet-revive.

Existing documentation links, warnings, installation guidance, and technical content remain unchanged.